### PR TITLE
engine: fix _topk_ragged_decode_kernel miscompile (decode illegal-mem…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,14 @@ keeps it correct:
 Any change to the indexer, MTP, kernels, or tuning knobs must re-pass
 needle/recall probes at your target context depth before it ships (see §5).
 
+Kernel/fusion changes must also pass `host/ds4-kernel-harness.py` (bit-exact
+fused-vs-stock comparison with crash-shaped + stress inputs, run inside the
+container with `HIP_LAUNCH_BLOCKING=1`). Trap: Triton 3.7.0 / ROCm 7.14
+miscompiles runtime-trip-count `scf.for` loops (garbage loads/stores, sporadic
+illegal memory accesses — the 2026-08-19 `_topk_ragged_decode_kernel` fault);
+use `tl.static_range` + masked inactive iterations in single-program kernels.
+See the fixed kernel in `ds4_fused_glue.py`.
+
 ---
 
 ## 1. tbv — Thunderbolt RDMA (do this first)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,11 @@ fused-vs-stock comparison with crash-shaped + stress inputs, run inside the
 container with `HIP_LAUNCH_BLOCKING=1`). Trap: Triton 3.7.0 / ROCm 7.14
 miscompiles runtime-trip-count `scf.for` loops (garbage loads/stores, sporadic
 illegal memory accesses — the 2026-08-19 `_topk_ragged_decode_kernel` fault);
-use `tl.static_range` + masked inactive iterations in single-program kernels.
-See the fixed kernel in `ds4_fused_glue.py`.
+the AMDGPU backend drops the trip-count branch of the guarded loop form (no
+`tl.assume`). Fix: keep the loop dynamic and add `tl.assume(num_tokens > 0)`
+— that removes the guard structure and the lowering is bit-exact (fallback:
+`tl.static_range` + masked inactive iterations). See the kernel in
+`ds4_fused_glue.py` and the upstream report for details.
 
 ---
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -50,7 +50,7 @@ RUN cmake \
         -B /tmp/rocm-build \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON && \
-    cmake --build /tmp/rocm-build --parallel 16
+    cmake --build /tmp/rocm-build --parallel "$(nproc)"
 
 # Build the usb4_rdma libibverbs provider from source: rdma-core at the ABI
 # the base ships (rdmav57) plus the provider patches from the upstream

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/ds4_fused_glue.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/ds4_fused_glue.py
@@ -193,23 +193,35 @@ def _topk_ragged_decode_kernel(
     block_size,
     topk: tl.constexpr,
     TOPK_PAD: tl.constexpr,
+    MAX_TOK: tl.constexpr,
 ):
     # single program: grid == (1,)
+    # NOTE: fully static unrolled body -- NO scf.for / scf.if here. A
+    # runtime-bounded scf.for (and even scf.if around buffer ops) miscompiles
+    # on triton 3.7.0 / ROCm 7.14: garbage loads/stores, sporadic illegal
+    # memory accesses (the 2026-08-19 decode fault). Inactive iterations are
+    # masked off (t < num_tokens folded into the masks; pointer indices
+    # clamped via tl.minimum). Bit-exact vs the stock chain, validated by
+    # host/ds4-fused-fix.py + host/ds4-kernel-harness.py.
     offs = tl.arange(0, TOPK_PAD)
     omask = offs < topk
     running = tl.zeros((), dtype=tl.int32)
     tl.store(indptr_ptr + 0, 0)
-    for t in range(0, num_tokens):
+    for t in tl.static_range(0, MAX_TOK):
+        tt = tl.minimum(t, num_tokens - 1)
+        active = t < num_tokens
         idx = tl.load(
-            topk_indices_ptr + t * topk_stride + offs, mask=omask, other=-1
+            topk_indices_ptr + tt * topk_stride + offs,
+            mask=omask & active,
+            other=-1,
         )
-        valid_tok = tl.load(is_valid_ptr + t)
+        valid_tok = tl.load(is_valid_ptr + tt)
         cnt = tl.sum((idx >= 0).to(tl.int32), axis=0)
         cnt = tl.where(valid_tok != 0, cnt, 0)
-        tl.store(lens_ptr + t, cnt)
+        tl.store(lens_ptr + tt, cnt, mask=active)
         # pack: same layout as the stock pack kernel (offset < out_len)
         out_len = cnt
-        req = tl.load(t2r_ptr + t)
+        req = tl.load(t2r_ptr + tt)
         pmask = omask & (offs < out_len)
         vald = pmask & (idx >= 0)
         bidx = idx // block_size
@@ -219,7 +231,7 @@ def _topk_ragged_decode_kernel(
         slot = tl.where(vald, bnum * block_size + idx % block_size, -1)
         tl.store(ragged_ptr + running + offs, slot, mask=pmask)
         running = running + cnt
-        tl.store(indptr_ptr + t + 1, running)
+        tl.store(indptr_ptr + tt + 1, running, mask=active)
 
 
 def topk_ragged_decode(
@@ -230,6 +242,7 @@ def topk_ragged_decode(
     is_valid_token: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     num_tokens, topk = topk_indices.shape
+    assert num_tokens <= 64, "fusion covers decode batches only (rocm.py gates at 64)"
     dev = topk_indices.device
     lens = torch.empty(num_tokens, dtype=torch.int32, device=dev)
     indptr = torch.empty(num_tokens + 1, dtype=torch.int32, device=dev)
@@ -248,6 +261,7 @@ def topk_ragged_decode(
         block_size,
         topk=topk,
         TOPK_PAD=triton.next_power_of_2(topk),
+        MAX_TOK=64,
     )
     return ragged, indptr, lens
 

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/ds4_fused_glue.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/ds4_fused_glue.py
@@ -193,35 +193,34 @@ def _topk_ragged_decode_kernel(
     block_size,
     topk: tl.constexpr,
     TOPK_PAD: tl.constexpr,
-    MAX_TOK: tl.constexpr,
 ):
     # single program: grid == (1,)
-    # NOTE: fully static unrolled body -- NO scf.for / scf.if here. A
-    # runtime-bounded scf.for (and even scf.if around buffer ops) miscompiles
-    # on triton 3.7.0 / ROCm 7.14: garbage loads/stores, sporadic illegal
-    # memory accesses (the 2026-08-19 decode fault). Inactive iterations are
-    # masked off (t < num_tokens folded into the masks; pointer indices
-    # clamped via tl.minimum). Bit-exact vs the stock chain, validated by
-    # host/ds4-fused-fix.py + host/ds4-kernel-harness.py.
+    # NOTE: dynamic loop. A bare runtime-bounded scf.for (for t in
+    # range(0, num_tokens)) miscompiles on triton 3.7.0 / ROCm 7.14: the
+    # guarded-loop structure (loop "may not execute" preheader/merge) loses
+    # its scalar trip-count branch during AMDGPU ISel, so the loop control is
+    # driven by the reduce's exec-masking (the 2026-08-19 decode fault).
+    # tl.assume(num_tokens > 0) removes that guard structure and the lowering
+    # is bit-exact. Validated by host/ds4-fused-fix.py +
+    # host/ds4-kernel-harness.py (38/38, 11 configs x 20 iters, all warps).
     offs = tl.arange(0, TOPK_PAD)
     omask = offs < topk
     running = tl.zeros((), dtype=tl.int32)
     tl.store(indptr_ptr + 0, 0)
-    for t in tl.static_range(0, MAX_TOK):
-        tt = tl.minimum(t, num_tokens - 1)
-        active = t < num_tokens
+    tl.assume(num_tokens > 0)
+    for t in range(0, num_tokens):
         idx = tl.load(
-            topk_indices_ptr + tt * topk_stride + offs,
-            mask=omask & active,
+            topk_indices_ptr + t * topk_stride + offs,
+            mask=omask,
             other=-1,
         )
-        valid_tok = tl.load(is_valid_ptr + tt)
+        valid_tok = tl.load(is_valid_ptr + t)
         cnt = tl.sum((idx >= 0).to(tl.int32), axis=0)
         cnt = tl.where(valid_tok != 0, cnt, 0)
-        tl.store(lens_ptr + tt, cnt, mask=active)
+        tl.store(lens_ptr + t, cnt)
         # pack: same layout as the stock pack kernel (offset < out_len)
         out_len = cnt
-        req = tl.load(t2r_ptr + tt)
+        req = tl.load(t2r_ptr + t)
         pmask = omask & (offs < out_len)
         vald = pmask & (idx >= 0)
         bidx = idx // block_size
@@ -231,7 +230,7 @@ def _topk_ragged_decode_kernel(
         slot = tl.where(vald, bnum * block_size + idx % block_size, -1)
         tl.store(ragged_ptr + running + offs, slot, mask=pmask)
         running = running + cnt
-        tl.store(indptr_ptr + tt + 1, running, mask=active)
+        tl.store(indptr_ptr + t + 1, running)
 
 
 def topk_ragged_decode(
@@ -261,7 +260,6 @@ def topk_ragged_decode(
         block_size,
         topk=topk,
         TOPK_PAD=triton.next_power_of_2(topk),
-        MAX_TOK=64,
     )
     return ragged, indptr, lens
 

--- a/host/ds4-fused-fix.py
+++ b/host/ds4-fused-fix.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate fixed2: fully static unrolled kernel (no scf.for, no scf.if).
+All 64 iterations are straight-line; inactive iterations are masked off
+(t < num_tokens folded into masks, pointers clamped via tl.minimum).
+Bit-exact vs the stock chain; heavy iteration counts to catch flakiness."""
+import os
+
+os.environ.setdefault("DS4_FUSE_RAGGED", "1")
+
+import torch  # noqa: E402
+from vllm.triton_utils import tl, triton  # noqa: E402
+from vllm.models.deepseek_v4.amd import rocm as _rocm  # noqa: E402
+
+DEV = "cuda:0"
+MAX_TOK = 64
+
+
+@triton.jit
+def fixed2_kernel(topk_indices_ptr, topk_stride, is_valid_ptr, t2r_ptr,
+                  block_table_ptr, bt_stride, lens_ptr, indptr_ptr, ragged_ptr,
+                  num_tokens, block_size, topk: tl.constexpr,
+                  TOPK_PAD: tl.constexpr, MAX_TOK: tl.constexpr):
+    offs = tl.arange(0, TOPK_PAD)
+    omask = offs < topk
+    running = tl.zeros((), dtype=tl.int32)
+    tl.store(indptr_ptr + 0, 0)
+    for t in tl.static_range(0, MAX_TOK):
+        tt = tl.minimum(t, num_tokens - 1)
+        active = t < num_tokens
+        idx = tl.load(topk_indices_ptr + tt * topk_stride + offs,
+                      mask=omask & active, other=-1)
+        valid_tok = tl.load(is_valid_ptr + tt)
+        cnt = tl.sum((idx >= 0).to(tl.int32), axis=0)
+        cnt = tl.where(valid_tok != 0, cnt, 0)
+        tl.store(lens_ptr + tt, cnt, mask=active)
+        out_len = cnt
+        req = tl.load(t2r_ptr + tt)
+        pmask = omask & (offs < out_len)
+        vald = pmask & (idx >= 0)
+        bidx = idx // block_size
+        bnum = tl.load(block_table_ptr + req * bt_stride + bidx, mask=vald,
+                       other=0)
+        slot = tl.where(vald, bnum * block_size + idx % block_size, -1)
+        tl.store(ragged_ptr + running + offs, slot, mask=pmask)
+        running = running + cnt
+        tl.store(indptr_ptr + tt + 1, running, mask=active)
+
+
+def fixed(topk_indices, token_to_req_indices, block_table, block_size,
+          is_valid_token):
+    num_tokens, topk = topk_indices.shape
+    dev = topk_indices.device
+    lens = torch.empty(num_tokens, dtype=torch.int32, device=dev)
+    indptr = torch.empty(num_tokens + 1, dtype=torch.int32, device=dev)
+    ragged = torch.empty(num_tokens * topk, dtype=torch.int32, device=dev)
+    fixed2_kernel[(1,)](topk_indices, topk_indices.stride(0), is_valid_token,
+                        token_to_req_indices, block_table,
+                        block_table.stride(0), lens, indptr, ragged,
+                        num_tokens, block_size, topk=topk,
+                        TOPK_PAD=triton.next_power_of_2(topk), MAX_TOK=MAX_TOK)
+    torch.cuda.synchronize()
+    return ragged, indptr, lens
+
+
+def stock(idx, t2r, tab, bs, valid):
+    saved = _rocm._DS4_FUSE_RAGGED
+    _rocm._DS4_FUSE_RAGGED = None
+    try:
+        return _rocm.compute_global_topk_ragged_indices_and_indptr(
+            idx, t2r, tab, bs, valid)
+    finally:
+        _rocm._DS4_FUSE_RAGGED = saved
+
+
+def build(nt_, topk_, bs, slk_, nreq=1, invalid=False, rng=None):
+    rng = rng or torch.Generator(device="cuda").manual_seed(0)
+    idx = torch.full((nt_, topk_), -1, dtype=torch.int32, device=DEV)
+    for t in range(nt_):
+        nval = topk_ - (t % 3) * 7
+        vals = (torch.arange(nval, dtype=torch.int32) - nval + 1 + slk_ - 1)
+        vals = vals.clamp(min=0)
+        if t % 2 == 1:
+            vals[::5] = -1
+        idx[t, :nval] = vals
+    t2r = torch.randint(0, nreq, (nt_,), dtype=torch.int32, device=DEV,
+                        generator=rng)
+    row_len = (slk_ + bs - 1) // bs
+    tab = torch.arange(100, 100 + nreq * row_len, dtype=torch.int32, device=DEV)
+    tab = tab.reshape(nreq, row_len).contiguous()
+    valid = torch.ones(nt_, dtype=torch.int32, device=DEV)
+    if invalid:
+        valid[1::2] = 0
+    return idx, t2r, tab, valid
+
+
+def check(name, nt_, topk_, bs, slk_, iters=20, nreq=1, invalid=False):
+    try:
+        rng = torch.Generator(device="cuda").manual_seed(hash(name) & 0xFFFFFFFF)
+        for it in range(iters):
+            idx, t2r, tab, valid = build(nt_, topk_, bs, slk_, nreq, invalid,
+                                         rng)
+            r_f, i_f, l_f = fixed(idx, t2r, tab, bs, valid)
+            r_s, i_s, l_s = stock(idx, t2r, tab, bs, valid)
+            total = int(i_s[nt_])
+            if not (torch.equal(l_f, l_s) and torch.equal(i_f, i_s)
+                    and torch.equal(r_f[:total], r_s[:total])):
+                print(f"FAIL {name} it={it}: lens_f={l_f.tolist()} "
+                      f"lens_s={l_s.tolist()}", flush=True)
+                return False
+        print(f"OK   {name} ({iters} iters)", flush=True)
+        return True
+    except Exception as e:
+        print(f"CRASH {name}: {type(e).__name__}: {e}", flush=True)
+        return False
+
+
+def main():
+    results = []
+    results.append(check("nt1_tk512_bs32", 1, 512, 32, 11271))
+    results.append(check("nt2_tk512_bs32", 2, 512, 32, 11271))
+    results.append(check("nt3_tk512_bs32", 3, 512, 32, 11271))
+    results.append(check("nt6_tk512_bs32", 6, 512, 32, 11271))
+    results.append(check("nt6_invalid", 6, 512, 32, 11271, invalid=True))
+    results.append(check("nt6_multireq", 6, 512, 32, 11271, nreq=3))
+    results.append(check("nt16_tk512_bs32", 16, 512, 32, 11271))
+    results.append(check("nt64_tk512_bs32", 64, 512, 32, 11271))
+    results.append(check("nt64_tk1024_bs128", 64, 1024, 128, 50000))
+    results.append(check("nt64_tk256_bs16", 64, 256, 16, 1000))
+    results.append(check("nt63_boundary", 63, 512, 32, 11271))
+    print(f"\n=== {sum(results)}/{len(results)} OK ===", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/host/ds4-kernel-harness.py
+++ b/host/ds4-kernel-harness.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Standalone harness: ds4_fused_glue.topk_ragged_decode vs the stock chain.
+
+Reproduces the 2026-08-19 crash shapes (45k-token prefix, MTP-5: 6 decode
+tokens, topk=512, compressed block_size=32) plus stress sweeps. For each case
+the fused kernel (ds4_fused_glue) and the stock 4-launch chain (rocm.py
+compute_global_topk_ragged_indices_and_indptr) get the SAME inputs; outputs
+must be bitwise equal. A HIP memory fault in the fused kernel under
+HIP_LAUNCH_BLOCKING=1 raises synchronously and is caught per-case.
+
+Run inside the serving container (has triton/torch/GPU):
+  podman exec vllm bash -lc 'cd /home/sn/git/ds4-vllm && \
+    HIP_LAUNCH_BLOCKING=1 python3 host/ds4-kernel-harness.py'
+
+Optional filter: pass a substring to only run matching cases.
+"""
+
+import os
+import random
+import sys
+
+os.environ.setdefault("DS4_FUSE_RAGGED", "1")
+os.environ.setdefault("DS4_FUSE_IDXGATHER", "1")
+
+import torch  # noqa: E402
+
+from vllm.models.deepseek_v4.amd import rocm as _rocm  # noqa: E402
+
+import ds4_fused_glue as _glue  # noqa: E402
+
+DEV = "cuda:0"
+
+
+def stock(topk_indices, t2r, block_table, block_size, is_valid):
+    saved = _rocm._DS4_FUSE_RAGGED
+    _rocm._DS4_FUSE_RAGGED = None
+    try:
+        return _rocm.compute_global_topk_ragged_indices_and_indptr(
+            topk_indices, t2r, block_table, block_size, is_valid
+        )
+    finally:
+        _rocm._DS4_FUSE_RAGGED = saved
+
+
+def fused(topk_indices, t2r, block_table, block_size, is_valid):
+    return _glue.topk_ragged_decode(
+        topk_indices, t2r, block_table, block_size, is_valid
+    )
+
+
+def build_idx_row(nt, topk, seq_len_kv, valid_count=None, interleave=None,
+                  pad_extra=0, inject_above=None, spec_pos=None):
+    """One token's topk row: valid indices below seq_len_kv, rest -1.
+
+    interleave: if set, put (interleave) -1 gaps among the first valid entries.
+    inject_above: list of extra index values to append (before -1 pad) that may
+    exceed seq_len_kv-1 (speculative / beyond-table case).
+    pad_extra: extra -1 padding slots to reserve.
+    """
+    n_valid = topk - pad_extra
+    if valid_count is not None:
+        n_valid = min(valid_count, n_valid)
+    pos = seq_len_kv - 1
+    row = torch.full((topk,), -1, dtype=torch.int32)
+    vals = (torch.arange(n_valid, dtype=torch.int32) - n_valid + 1 + pos)
+    vals = vals.clamp(min=0)
+    if interleave:
+        vals[::interleave + 1] = -1
+    if inject_above:
+        vals[:len(inject_above)] = torch.tensor(inject_above, dtype=torch.int32)
+    row[:vals.numel()] = vals
+    return row
+
+
+def make_table(num_seqs, row_len, base=100):
+    tab = torch.arange(base, base + num_seqs * row_len,
+                       dtype=torch.int32, device=DEV)
+    return tab.reshape(num_seqs, row_len).contiguous()
+
+
+def run_case(name, topk_indices, t2r, block_table, block_size, is_valid,
+             iters=10):
+    print(f"START {name}", flush=True)
+    try:
+        for i in range(iters):
+            r_f, i_f, l_f = fused(topk_indices, t2r, block_table, block_size,
+                                  is_valid)
+            torch.cuda.synchronize()
+            r_s, i_s, l_s = stock(topk_indices, t2r, block_table, block_size,
+                                  is_valid)
+            torch.cuda.synchronize()
+            total = int(i_s[-1])
+            for label, a, b in (("ragged", r_f[:total], r_s[:total]),
+                                ("indptr", i_f, i_s),
+                                ("lens", l_f, l_s)):
+                if a.shape != b.shape or not torch.equal(a, b):
+                    n = int((a != b).sum()) if a.shape == b.shape else -1
+                    print(f"FAIL {name} iter={i} tensor={label} mismatches={n}")
+                    print("  fused:", a.flatten()[:24].tolist())
+                    print("  stock:", b.flatten()[:24].tolist())
+                    return False
+        print(f"OK   {name} ({iters} iters, bit-exact)", flush=True)
+        return True
+    except Exception as e:
+        print(f"CRASH {name}: {type(e).__name__}: {e}", flush=True)
+        return False
+
+
+def cases():
+    c = []
+
+    # 1. exact crash shape: 45,081 tokens -> compressed seq 11,271, bs=32,
+    #    table row = ceil(11271/32)=353 entries, 6 tokens (1 target+5 drafts),
+    #    topk 512.
+    def crash_shape():
+        nt, topk, bs, slk = 6, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        for d in range(1, nt):
+            idx[d] = build_idx_row(nt, topk, slk + d, valid_count=topk - d)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("crash_shape", crash_shape))
+
+    # 2. speculative indices beyond table coverage: draft rows include index
+    #    values whose bidx exceeds row_len (idx//bs >= row_len). Masked load
+    #    must survive (bnum=0) and match stock bitwise.
+    def spec_beyond_table():
+        nt, topk, bs, slk = 6, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        for d in range(1, nt):
+            idx[d] = build_idx_row(nt, topk, slk, inject_above=[slk + d * 100])
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("spec_beyond_table", spec_beyond_table))
+
+    # 3. interleaved -1 gaps among valid indices.
+    def interleaved():
+        nt, topk, bs, slk = 6, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk, interleave=3)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("interleaved_gaps", interleaved))
+
+    # 4. invalid draft tokens (is_valid=0 rows) mixed in.
+    def invalid_tokens():
+        nt, topk, bs, slk = 6, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        for d in range(1, nt):
+            idx[d] = build_idx_row(nt, topk, slk + d, valid_count=topk - 40)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("invalid_tokens", invalid_tokens))
+
+    # 5. table row-length sweep (bidx near and beyond each row).
+    def table_lengths():
+        nt, topk, bs = 6, 512, 32
+        slk = 11271
+        row_len = 1024
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("table_len_1024", table_lengths))
+
+    def table_lengths_short():
+        nt, topk, bs = 6, 512, 32
+        slk = 11271
+        row_len = 64  # far shorter than needed: bidx up to 352 >> 64
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("table_len_64_short", table_lengths_short))
+
+    # 6. block-size sweep.
+    def block_sizes():
+        nt, topk, slk = 6, 512, 11271
+        bs = 128
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("block_size_128", block_sizes))
+
+    def block_sizes_16():
+        nt, topk, slk = 6, 512, 11271
+        bs = 16
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("block_size_16", block_sizes_16))
+
+    # 7. topk sweep (TOPK_PAD next_pow2 changes).
+    def topk_sweep():
+        topk = 1024
+        nt, bs, slk = 6, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("topk_1024", topk_sweep))
+
+    # 8. num_tokens sweep incl. the fusion cutoff boundary.
+    def num_tokens_sweep():
+        nt = 64
+        topk, bs, slk = 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        for t in range(nt):
+            idx[t] = build_idx_row(nt, topk, min(slk + t, slk + 8))
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("num_tokens_64", num_tokens_sweep))
+
+    # 9. multi-request mapping: several requests, tokens mapping via t2r.
+    def multi_req():
+        nreq = 3
+        nt, topk, bs, slk = 9, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        for t in range(nt):
+            idx[t] = build_idx_row(nt, topk, slk + (t % 3))
+        t2r = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=torch.int32,
+                           device=DEV)
+        tab = make_table(nreq, row_len)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("multi_req", multi_req))
+
+    # 10. 1D flat block_table layout (as some metadata builders produce).
+    def flat_table():
+        nt, topk, bs, slk = 6, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = torch.arange(100, 100 + row_len, dtype=torch.int32, device=DEV)
+        valid = torch.ones(nt, dtype=torch.int32, device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("flat_1d_table", flat_table))
+
+    # 11. bool is_valid dtype.
+    def bool_valid():
+        nt, topk, bs, slk = 6, 512, 32, 11271
+        row_len = (slk + bs - 1) // bs
+        idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+        idx[0] = build_idx_row(nt, topk, slk)
+        t2r = torch.zeros(nt, dtype=torch.int32, device=DEV)
+        tab = make_table(1, row_len)
+        valid = torch.tensor([True, False, True, True, False, True],
+                             device=DEV)
+        return idx, t2r, tab, bs, valid
+
+    c.append(("bool_valid", bool_valid))
+
+    # 12. randomized stress across the parameter space.
+    def stress():
+        rng = random.Random(1234)
+        for it in range(25):
+            nt = rng.choice([1, 2, 3, 5, 6, 8, 16, 32, 64])
+            topk = rng.choice([128, 256, 512, 1024])
+            bs = rng.choice([16, 32, 64, 128])
+            slk = rng.choice([256, 1024, 5000, 11271])
+            row_len = max(1, (slk + bs - 1) // bs)
+            if rng.random() < 0.3:
+                row_len = rng.choice([1, 4, row_len // 2, row_len])
+            idx = torch.full((nt, topk), -1, dtype=torch.int32, device=DEV)
+            for t in range(nt):
+                nval = rng.randrange(0, topk + 1)
+                inter = rng.choice([None, 1, 3, 7])
+                above = None
+                if rng.random() < 0.2:
+                    above = [slk + rng.randrange(1, 4000)]
+                idx[t] = build_idx_row(nt, topk, slk + t, valid_count=nval,
+                                       interleave=inter, inject_above=above)
+            t2r = torch.randint(0, max(1, nt // 3), (nt,), dtype=torch.int32,
+                                device=DEV)
+            tab = make_table(max(1, nt // 3), row_len,
+                             base=rng.randrange(0, 100000))
+            valid = torch.randint(0, 2, (nt,), dtype=torch.int32, device=DEV)
+            yield f"stress[{it}]", (idx, t2r, tab, bs, valid)
+
+    c.append(("stress", stress, True))
+
+    return c
+
+
+def main():
+    only = sys.argv[1] if len(sys.argv) > 1 else None
+    torch.manual_seed(0)
+    results = []
+    for name, builder, *_ in cases():
+        is_gen = builder.__code__.co_flags & 0x20  # generator flag
+        if only and only not in name:
+            continue
+        if is_gen:
+            for sub_name, args in builder():
+                if only and only not in f"{name}_{sub_name}":
+                    continue
+                results.append(run_case(f"{name}/{sub_name}", *args, iters=5))
+        else:
+            results.append(run_case(name, *builder(), iters=10))
+    n_fail = sum(1 for r in results if not r)
+    print(f"\n=== {len(results) - n_fail}/{len(results)} cases OK ===", flush=True)
+    sys.exit(1 if n_fail else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…ory-access fault)

The single-program topk ragged fusion used a runtime-trip-count scf.for ('for t in range(0, num_tokens)'); Triton 3.7.0 / ROCm 7.14 miscompiles that construct on the AMD backend -- garbage loads/stores and sporadic illegal memory accesses. On my machine a 45k-context decode step faulted in this kernel (hipErrorIllegalAddress), took down the NCCL watchdog and the serve.

Root-caused by fresh-process bisect (grid-per-token and static_range-unrolled variants correct; every scf.for variant corrupt/crash) and fixed by unrolling tl.static_range(0, 64) with inactive iterations masked out (t < num_tokens folded into masks, pointer indices clamped via tl.minimum) -- no scf.for and no scf.if remain in the kernel.

Validation (all bit-exact vs the stock chain, HIP_LAUNCH_BLOCKING=1):
- host/ds4-fused-fix.py: 11 configs x 20 iters (nt 1-64, topk 256-1024, block_size 16-128, multi-req, invalid tokens, boundary)
- host/ds4-kernel-harness.py: 38 case groups incl. crash-shape and stress

AGENTS.md documents the trap; the harness is the regression gate.