### PR TITLE
Support DeepSeek-V4-Flash-Vision-Exp (image input) from the same image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,9 @@ Three independent layers, build/verify them in this order:
   `podman`, `distrobox`, `git`, build toolchain. A stock kernel is fine —
   nothing here needs a patched thunderbolt core.
 - The model weights **`deepseek-ai/DeepSeek-V4-Flash-0731`** (~150 GB) downloaded
-  on **both** boxes (`hf download deepseek-ai/DeepSeek-V4-Flash-0731`).
+  on **both** boxes (`hf download deepseek-ai/DeepSeek-V4-Flash-0731`). For
+  image input, `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` instead; the
+  launcher detects a vision checkpoint from its config (README "Vision").
 - Root/sudo on both boxes (kernel modules, systemd units).
 - **Secure Boot disabled on both boxes**, unless the box has an enrolled MOK:
   `odl_tb5.ko` is built locally, and `odl-swap.sh` signs it with the enrolled
@@ -163,7 +165,8 @@ distrobox enter vllm -- ibv_devices             # gate: lists usb4_rdma0 (if §1
 
 Deploy the `host/` files per README §3 and set the site values in
 `~/ds4-config.yaml` on box1 (head/worker IPs, container name, `transport:
-rdma|tcp|odl`, RDMA HCA pin, disk KV). Two rules that bite:
+rdma|tcp|odl`, RDMA HCA pin, disk KV; `model:` set to the Vision-Exp
+checkpoint for image input). Two rules that bite:
 
 - `ds4-cluster-env*.sh` **must be byte-identical on both boxes** — the two TP
   ranks silently diverge otherwise. Copy the same files to both.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ order:
 ```bash
 # 0. model weights, ~150 GB, on BOTH boxes (https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731)
 hf download deepseek-ai/DeepSeek-V4-Flash-0731
+#    image input? download deepseek-ai/DeepSeek-V4-Flash-Vision-Exp instead -- see "Vision" below
 
 # 1. Thunderbolt fabric, on BOTH boxes (stock kernel; ONE cable between them)
 odinlink/build-odinlink.sh && sudo odinlink/install-odinlink.sh
@@ -139,7 +140,9 @@ ds4vllm-public/
 - **Model weights**: [`deepseek-ai/DeepSeek-V4-Flash-0731`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731)
   (~150 GB checkpoint). Not included — `hf download deepseek-ai/DeepSeek-V4-Flash-0731`
   on both boxes (the `model:` key in `ds4-config.yaml` takes an HF id or a local
-  path). Served as `deepseek-v4-flash`.
+  path). Served as `deepseek-v4-flash`. For image input use
+  [`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
+  instead — see **Vision** below.
 
 ---
 
@@ -203,7 +206,7 @@ Site specifics live in **`host/ds4-config.yaml`** — deploy it (edited for your
 site) as `~/ds4-config.yaml` on box1 next to the scripts:
 
 ```yaml
-model: deepseek-ai/DeepSeek-V4-Flash-0731   # HF id or local path; weights on BOTH boxes
+model: deepseek-ai/DeepSeek-V4-Flash-0731   # HF id or local path; weights on BOTH boxes (Vision-Exp for image input, see "Vision")
 transport: odl         # odl | tcp — which ds4-cluster-env.<transport>.sh the cluster sources
 head_ip: 192.168.100.1
 worker_ip: 192.168.100.2
@@ -240,6 +243,71 @@ container heal → ray on both boxes → `vllm serve` → API/all-reduce verify)
 purpose — `examples/systemd/ds4-vllm.service` wraps the same script if you
 want a unit. The env files must stay **identical on both
 boxes** — the two TP ranks silently diverge otherwise. 
+
+---
+
+## Vision (DeepSeek-V4-Flash-Vision-Exp)
+
+The same image and scripts serve the multimodal
+[`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
+checkpoint — the text model plus a BF16 vision tower and aligner — taking
+images through the standard OpenAI chat `image_url` content parts. Everything
+else is as for the text checkpoint: TP=2 over the fabric, 512K context, MTP-5
+speculative decoding, fp8 KV, the disk KV tier, the `deepseek-v4-flash` served
+name. This port was built against checkpoint revision `e46e16b`.
+
+```bash
+hf download deepseek-ai/DeepSeek-V4-Flash-Vision-Exp    # on BOTH boxes
+```
+
+Then point `model:` in `~/ds4-config.yaml` on box1 at it, and restart:
+
+```yaml
+model: deepseek-ai/DeepSeek-V4-Flash-Vision-Exp   # or a local copy of it
+```
+
+```bash
+./ds4-serve.sh restart
+curl -s http://127.0.0.1:1234/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "deepseek-v4-flash",
+  "messages": [{"role": "user", "content": [
+    {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/3/3f/JPEG_example_flower.jpg"}},
+    {"type": "text", "text": "What is in this picture?"}]}]}'
+```
+
+There is no switch to flip: the launcher reads the checkpoint's `config.json`
+and, when it declares a vision tower (`vision_n_layers`), passes
+`--hf-overrides '{"architectures":["DeepseekV4VForConditionalGeneration"],"num_nextn_predict_layers":1}'`.
+That is needed because the checkpoint's own config still declares the text
+architecture, and declares its (identical) three-stage DSpark drafter as three
+predictor layers where the text checkpoint declares one. The serve log says
+`vision checkpoint (vision_n_layers=32): serving the multimodal wrapper` when
+it took effect. To go back, point `model:` at the text checkpoint and restart.
+
+What the engine does differently for this checkpoint (rows in
+`container/patches/MANIFEST.md`):
+
+- **Image preprocessing + tower** (`mm_preprocess.py`, `vision.py`,
+  `vision_model.py`): the reference resize/grid/C4 token layout, the BF16 ViT
+  and aligner, and the five out-of-vocabulary image sentinel ids the language
+  model sees for expert routing and attention.
+- **Expert routing**: image positions use the checkpoint's visual expert
+  selection bias; text positions keep the text bias and the fused gfx1151
+  selector.
+- **Span-bidirectional attention**: inside each image span attention is
+  bidirectional, as in the reference model; text tokens take the unchanged
+  causal path. `DS4_VISION_SPAN_ATTN=0` in `ds4-cluster-env.sh` (both boxes)
+  keeps image spans causal instead. An image span cut by a chunked-prefill
+  boundary is attended causally for the cut fragment.
+- **MTP**: the DSpark drafter runs unchanged (one predictor, three internal
+  stages). Its drafts over image spans are merely lower quality — the target
+  model verifies every drafted token, so outputs are unaffected.
+
+Images cost prompt tokens (a few hundred per image at the default grid) and
+count against `max_ctx` like text. Text-only requests to the vision
+checkpoint take the same path as the text checkpoint. This profile has had
+less soak time than the text checkpoint; the text profile stays the
+reference for the performance table above.
 
 ---
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -4,7 +4,7 @@
 # TheRock/ROCm gfx1151 base image — the exact base the patches were developed
 # against. The base already contains the full ROCm 7 + PyTorch + vLLM build
 # (vLLM commit 470229c); this file applies the DeepSeek-V4 / DSpark patch
-# (patches/vllm-upstream.patch, 37 files), overlays the 18 new files from
+# (patches/vllm-upstream.patch, 41 files), overlays the 21 new files from
 # ./rootfs, builds the OdinLink userspace (the RCCL net plugin and the odl_ar2
 # all-reduce) and the hand-written decode kernels, and rebuilds ROCr. Third-party sources are FETCHED at pinned
 # commits, not vendored (network needed on first build).
@@ -82,8 +82,8 @@ RUN git clone https://github.com/Geramy/OdinLink-Five /tmp/odinlink && \
 
 FROM ${DS4_BASE}
 
-# Apply the vLLM patch-set to the base's own sources (37 files), then overlay
-# the 18 new files from rootfs/ (which mirrors "/"). The patch is the same
+# Apply the vLLM patch-set to the base's own sources (41 files), then overlay
+# the 21 new files from rootfs/ (which mirrors "/"). The patch is the same
 # reviewable diff in patches/; container/verify-patches.sh proves it applies.
 COPY container/patches/vllm-upstream.patch /tmp/
 RUN cd / && git apply -p1 --whitespace=nowarn /tmp/vllm-upstream.patch && rm /tmp/vllm-upstream.patch

--- a/container/patches/MANIFEST.md
+++ b/container/patches/MANIFEST.md
@@ -3,10 +3,10 @@
 All changes are a single overlay on the **`kyuz0/vllm-therock-gfx1151`** base
 (pinned digest `sha256:25fd294f…`, which ships vLLM commit **`470229c`**).
 
-- **37 modified** files — shipped as `vllm-upstream.patch` in this folder, applied
+- **41 modified** files — shipped as `vllm-upstream.patch` in this folder, applied
   to the base's own sources at image build (base → patched). The diffs double as
   review material: a reader can see exactly what changed versus upstream.
-- **18 new** files — added by the patch set; no diff (whole file is new). Their
+- **21 new** files — added by the patch set; no diff (whole file is new). Their
   final form is in `../rootfs`, which the Dockerfile overlays after patching.
 - 1 file (`aiter_meta/csrc/cpp_itfs/utils.py`) was flagged changed by the image
   layer but is **byte-identical** to the base (metadata-only touch) and is
@@ -20,13 +20,19 @@ modules and the aiter config).
 | file | Δ | purpose |
 |---|---|---|
 | `vllm/models/deepseek_v4/__init__.py` | +1/-1 | model registration |
-| `vllm/models/deepseek_v4/amd/model.py` | +86/-4 | AMD DSpark model wiring (custom all-reduce hook, layer glue); folds the decode layer's `attn_norm`/`ffn_norm` RMSNorms into the mhc kernels' `layer_input` write (kernel support pre-existed, was never wired), dropping two standalone norm kernels per layer |
-| `vllm/models/deepseek_v4/amd/rocm.py` | +67 | ROCm-specific op paths; `DS4_FUSE_RAGGED` single-kernel decode topk ragged build |
-| `vllm/models/deepseek_v4/amd/dspark_mtp.py` | **new (1485)** | DSpark Multi-Token-Prediction (MTP) drafter: fast-replay contract, self-managed step-0 draft CUDA graphs (`DS4_MTP_CUDAGRAPH`), fused in-graph glue (`DS4_MTP_FUSE_GLUE`), vocab-sharded markov chain + distributed argmax (`DS4_MTP_VOCAB_SHARD`) |
+| `vllm/models/deepseek_v4/amd/model.py` | +110/-4 | AMD DSpark model wiring (custom all-reduce hook, layer glue); folds the decode layer's `attn_norm`/`ffn_norm` RMSNorms into the mhc kernels' `layer_input` write (kernel support pre-existed, was never wired), dropping two standalone norm kernels per layer; Vision-Exp `bias_vl` (visual expert selection bias) registration, hash-layer bias skipping on load, and handoff to the router |
+| `vllm/models/deepseek_v4/amd/rocm.py` | +118/-4 | ROCm-specific op paths; `DS4_FUSE_RAGGED` single-kernel decode topk ragged build; the sparse-SWA prefill combine kernel takes per-token image-span visibility from the Vision-Exp wrapper (bidirectional attention within `[IMAGE_START..IMAGE_END]`, reference `get_window_topk_idxs_visible` semantics; text tokens keep the exact causal window) |
+| `vllm/models/deepseek_v4/amd/dspark_mtp.py` | **new (1488)** | DSpark Multi-Token-Prediction (MTP) drafter: fast-replay contract, self-managed step-0 draft CUDA graphs (`DS4_MTP_CUDAGRAPH`), fused in-graph glue (`DS4_MTP_FUSE_GLUE`), vocab-sharded markov chain + distributed argmax (`DS4_MTP_VOCAB_SHARD`) |
+| `vllm/models/deepseek_v4/mm_preprocess.py` | **new (320)** | DeepSeek-V4-Flash-Vision-Exp image resize/grid/C4 token preprocessing and the multimodal processor (selected when the checkpoint config declares `vision_n_layers`) |
+| `vllm/models/deepseek_v4/vision.py` | **new (148)** | Vision-Exp BF16 vision tower and image-to-language aligner |
+| `vllm/models/deepseek_v4/vision_model.py` | **new (171)** | `DeepseekV4VForConditionalGeneration`: the multimodal wrapper around the text model (weight mapping, sentinel-block embedding merge, per-token image-span visibility for the attention kernel, DSpark stash delegation for MTP) |
 | `vllm/models/deepseek_v4/attention.py` | +32/-4 | MLA / sparse-attention wiring |
 | `vllm/models/deepseek_v4/common/ops/cache_utils.py` | +43 | KV-cache helpers (fp8_ds_mla latents) |
 | `vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py` | +101/-40 | fused compress+quant of the MLA KV latent (UE8M0 fp8) |
 | `vllm/models/deepseek_v4/common/ops/fused_indexer_q.py` | +82 | indexer-Q quantization (Hadamard128 + FP4 QAT) |
+| `vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py` | +51/-4 | Vision-Exp expert routing: select the text or visual expert correction bias per token, substitute a text id for image sentinels before hash-table routing, and use the exact torch selector for the per-token-bias case (the fused gfx1151 selector takes one bias vector); text-only models keep the fused path untouched |
+| `vllm/model_executor/models/registry.py` | +6 | register `DeepseekV4VForConditionalGeneration` (the Vision-Exp checkpoint still declares the text architecture, so it is selected by `--hf-overrides`) |
+| `vllm/v1/engine/input_processor.py` | +8/-1 | admit the five Vision-Exp out-of-vocabulary image sentinel ids when a vision tower is configured |
 
 ## Sparse indexer / mid-context retrieval
 | file | Δ | purpose |
@@ -78,6 +84,7 @@ modules and the aiter config).
 | `vllm/v1/worker/gpu_model_runner.py` | +8 | model-runner hook |
 | `vllm/compilation/breakable_cudagraph.py` | +147/-5 | piecewise cudagraph, keeps attention + custom all-reduce eager; call-time (not import-time) enable gating for prestarted workers, padding-row zeroing after replayed eager segments, functional eager break for out-of-place ops |
 | `vllm/v1/spec_decode/llm_base_proposer.py` | +99/-6 | MTP proposer adjustment; `DS4_MTP_FAST_REPLAY` skips dead per-iteration work for stash-style drafters; hands the DSpark drafter its anchors (`set_anchor_indices`) for padded drafter batches |
+| `vllm/config/speculative.py` | +10/-1 | declare `n_predict=1` for every deepseek_v4 draft config: the DSpark drafter is one predictor with three internal stages, and the draft config is loaded fresh so a target `--hf-overrides` cannot reach it -- Vision-Exp's declared 3 would otherwise reject MTP-5 at boot |
 
 ## Disk KV cache (`fs_lru`, distributed)
 | file | Δ | purpose |

--- a/container/patches/vllm-upstream.patch
+++ b/container/patches/vllm-upstream.patch
@@ -11,7 +11,37 @@
      from .xpu.mtp import DeepSeekV4MTP  # type: ignore[assignment]
 --- a/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/amd/model.py
 +++ b/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/amd/model.py
-@@ -311,7 +311,12 @@
+@@ -159,6 +159,16 @@
+                 requires_grad=False,
+             )
+ 
++        # Vision-Exp carries a second selection-only expert bias. The router
++        # chooses it per image position; text positions keep the existing bias.
++        self.vl_vocab_size = config.vocab_size
++        self.gate.bias_vl = None
++        if int(getattr(config, "vision_n_layers", 0) or 0) > 0:
++            self.gate.bias_vl = nn.Parameter(
++                torch.empty(config.n_routed_experts, dtype=torch.float32),
++                requires_grad=False,
++            )
++
+         if config.n_shared_experts is None:
+             self.shared_experts = None
+         else:
+@@ -198,6 +208,12 @@
+             swiglu_limit=self.swiglu_limit,
+             router_logits_dtype=torch.float32,
+         )
++        if self.gate.bias_vl is not None:
++            # FusedMoE owns the actual router. Attach the visual bias there so
++            # its normal custom-op path can select per-token routing without
++            # replacing the DS4 expert kernels.
++            self.experts.router.vision_e_score_correction_bias = self.gate.bias_vl
++            self.experts.router.vision_vocab_size = self.vl_vocab_size
+ 
+     def forward(
+         self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None
+@@ -311,7 +327,12 @@
          hc_fn: torch.Tensor,
          hc_scale: torch.Tensor,
          hc_base: torch.Tensor,
@@ -24,7 +54,7 @@
          post_mix, res_mix, layer_input = self.mhc_pre(
              residual=x,
              fn=hc_fn,
-@@ -322,6 +327,8 @@
+@@ -322,6 +343,8 @@
              hc_sinkhorn_eps=self.hc_eps,
              hc_post_mult_value=self.hc_post_alpha,
              sinkhorn_repeat=self.hc_sinkhorn_iters,
@@ -33,7 +63,7 @@
          )
          return layer_input, post_mix, res_mix
  
-@@ -347,7 +354,8 @@
+@@ -347,7 +370,8 @@
              # Run standalone hc_pre on first layer
              residual = x
              x, post_mix, res_mix = self.hc_pre(
@@ -43,7 +73,7 @@
              )
          else:
              residual, post_mix, res_mix, x = self.mhc_fused_post_pre(
-@@ -363,9 +371,13 @@
+@@ -363,9 +387,13 @@
                  self.hc_eps,
                  self.hc_post_alpha,
                  self.hc_sinkhorn_iters,
@@ -58,7 +88,7 @@
          x = self.attn(positions, x, None)
  
          residual, post_mix, res_mix, x = self.mhc_fused_post_pre(
-@@ -381,8 +393,12 @@
+@@ -381,8 +409,12 @@
              self.hc_eps,
              self.hc_post_alpha,
              self.hc_sinkhorn_iters,
@@ -72,7 +102,7 @@
          x = self.ffn(x, input_ids)
          return x, residual, post_mix, res_mix
  
-@@ -467,6 +483,21 @@
+@@ -467,6 +499,21 @@
              device=self.device,
          )
  
@@ -94,7 +124,7 @@
          if get_pp_group().is_first_rank:
              self.embed_tokens = VocabParallelEmbedding(
                  config.vocab_size,
-@@ -529,6 +560,24 @@
+@@ -529,6 +576,24 @@
              )
          else:
              self._mtp_hidden_buffer = None
@@ -119,7 +149,7 @@
  
      def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
          return self.embed_tokens(input_ids)
-@@ -571,7 +620,11 @@
+@@ -571,7 +636,11 @@
              hidden_states = intermediate_tensors["hidden_states"]
  
          residual, post_mix, res_mix = None, None, None
@@ -132,7 +162,7 @@
              hidden_states, residual, post_mix, res_mix = layer(
                  hidden_states,
                  positions,
-@@ -580,6 +633,29 @@
+@@ -580,6 +649,29 @@
                  res_mix,
                  residual,
              )
@@ -162,7 +192,7 @@
          if layer is not None and self.has_tilelang:
              hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
  
-@@ -589,6 +665,9 @@
+@@ -589,6 +681,9 @@
          # Stash pre-hc_head residual for the MTP draft (captured copy_).
          num_tokens = hidden_states.shape[0]
          self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
@@ -172,7 +202,22 @@
  
          hidden_states = self.hc_head_op(
              hidden_states,
-@@ -807,6 +886,9 @@
+@@ -690,6 +785,14 @@
+                 else:
+                     if is_pp_missing_parameter(name, self):
+                         continue
++                    # Vision-Exp serializes text/visual gate biases even for
++                    # hash-routed layers. Those layers select experts through
++                    # tid2eid and intentionally have no correction-bias param.
++                    if (
++                        name not in params_dict
++                        and name.endswith(".ffn.gate.e_score_correction_bias")
++                    ):
++                        continue
+                     param = params_dict[name]
+                     weight_loader = getattr(
+                         param, "weight_loader", default_weight_loader
+@@ -807,6 +910,9 @@
          """Pre-hc_head residual stream buffer (max_num_batched_tokens,
          hc_mult * hidden_size) for the MTP draft model. Populated by
          forward(); valid after each target step."""
@@ -207,7 +252,101 @@
  
  def _build_indptr_from_lengths(lengths: torch.Tensor) -> torch.Tensor:
      lengths = lengths.to(dtype=torch.int32).contiguous()
-@@ -238,6 +254,20 @@
+@@ -53,11 +69,15 @@
+     query_start_loc_ptr,
+     seq_lens_ptr,
+     gather_lens_ptr,
++    vis_left_ptr,
++    vis_right_ptr,
+     M,
+     N,
+     TOP_K: tl.constexpr,
+     COMPRESS_RATIO: tl.constexpr,
+     WINDOW_SIZE: tl.constexpr,
++    SWA_WIDTH: tl.constexpr,
++    HAS_VIS: tl.constexpr,
+     TOPK_WIDTH: tl.constexpr,
+     PADDED_TOP_K: tl.constexpr,
+ ):
+@@ -78,7 +98,22 @@
+         token_idx_in_query = token_idx - query_start
+         pos = start_pos + token_idx_in_query
+         topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, TOP_K)
+-        swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
++        if HAS_VIS:
++            # Reference get_window_topk_idxs_visible: an in-span query sees
++            # forward to the span end (right) and its window start is pulled
++            # back so the span start stays visible (left_add). Clamped to the
++            # gathered SWA buffer [gather_start, seq_len). left==right==0
++            # (text tokens) reduces exactly to the causal window below.
++            vleft = tl.load(vis_left_ptr + token_idx)
++            vright = tl.load(vis_right_ptr + token_idx)
++            left_add = tl.maximum(vleft - (WINDOW_SIZE - 1), 0)
++            swa_start = tl.maximum(pos - (WINDOW_SIZE - 1) - left_add, 0)
++            swa_start = tl.maximum(swa_start, gather_start)
++            swa_end = tl.minimum(pos + vright, seq_len - 1)
++            swa_len = tl.minimum(swa_end - swa_start + 1, SWA_WIDTH)
++        else:
++            swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
++            swa_start = pos - swa_len + 1
+ 
+         topk_offset = tl.arange(0, PADDED_TOP_K)
+         topk_mask = topk_offset < topk_len
+@@ -96,13 +131,13 @@
+             mask=topk_mask,
+         )
+ 
+-        swa_offset = tl.arange(0, WINDOW_SIZE)
++        swa_offset = tl.arange(0, SWA_WIDTH)
+         tl.store(
+             combined_indices_ptr
+             + token_idx * combined_indices_stride
+             + topk_len
+             + swa_offset,
+-            M * batch_idx + N + swa_offset + pos - swa_len + 1 - gather_start,
++            M * batch_idx + N + swa_start - gather_start + swa_offset,
+             mask=swa_offset < swa_len,
+         )
+ 
+@@ -119,12 +154,20 @@
+     topk: int,
+     M: int,
+     N: int,
++    vis_left: torch.Tensor | None = None,
++    vis_right: torch.Tensor | None = None,
++    vis_extra: int = 0,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
+     topk_indices = topk_indices.reshape(topk_indices.shape[0], -1).contiguous()
+     num_tokens = topk_indices.shape[0]
+     num_reqs = seq_lens.shape[0]
++    # Image-span visibility widens the SWA slice by at most vis_extra
++    # (= vision_max_n_token) columns; see the width bound in the kernel
++    # comment. Text-only calls keep the exact original width and arithmetic.
++    has_vis = vis_left is not None and vis_right is not None and vis_extra > 0
++    swa_width = window_size + (vis_extra if has_vis else 0)
+     combined_topk = (
+-        (topk + window_size + _SPARSE_PREFILL_TOPK_ALIGNMENT - 1)
++        (topk + swa_width + _SPARSE_PREFILL_TOPK_ALIGNMENT - 1)
+         // _SPARSE_PREFILL_TOPK_ALIGNMENT
+         * _SPARSE_PREFILL_TOPK_ALIGNMENT
+     )
+@@ -148,11 +191,15 @@
+         query_start_loc,
+         seq_lens,
+         gather_lens,
++        vis_left if has_vis else combined_lens,
++        vis_right if has_vis else combined_lens,
+         M,
+         N,
+         TOP_K=topk,
+         COMPRESS_RATIO=compress_ratio,
+         WINDOW_SIZE=window_size,
++        SWA_WIDTH=swa_width,
++        HAS_VIS=has_vis,
+         TOPK_WIDTH=topk_indices.shape[-1],
+         PADDED_TOP_K=triton.next_power_of_2(topk_indices.shape[-1]),
+     )
+@@ -238,6 +285,20 @@
      num_tokens = topk_indices.shape[0]
      topk = topk_indices.shape[1]
  
@@ -228,7 +367,7 @@
      topk_lens = torch.empty(num_tokens, dtype=torch.int32, device=topk_indices.device)
      _compute_topk_lens_kernel[(num_tokens,)](
          topk_lens,
-@@ -713,6 +743,43 @@
+@@ -713,6 +774,43 @@
                  topk_ragged_indices = attn_metadata.c128a_decode_topk_ragged_indices
                  topk_ragged_indptr = attn_metadata.c128a_decode_topk_ragged_indptr
  
@@ -272,6 +411,36 @@
          rocm_sparse_attn_decode(
              q=q,
              kv_cache=kv_cache,
+@@ -762,6 +860,17 @@
+         assert query_start_loc is not None
+         prefill_token_base = query_start_loc_cpu[num_decodes]
+ 
++        # Image-span visibility published by the Vision-Exp wrapper for this
++        # step (absent for text-only models/steps). Rows cover the whole flat
++        # token batch, decode tokens first — slice to the prefill rows.
++        vis = getattr(get_forward_context(), "ds4_image_visibility", None)
++        vis_left = vis_right = None
++        vis_extra = 0
++        if vis is not None:
++            vis_left = vis[0][num_decode_tokens:][:num_prefill_tokens]
++            vis_right = vis[1][num_decode_tokens:][:num_prefill_tokens]
++            vis_extra = vis[2]
++
+         if not swa_only:
+             if self.compress_ratio == 4:
+                 assert self.topk_indices_buffer is not None
+@@ -836,6 +945,11 @@
+                 top_k,
+                 M,
+                 N,
++                vis_left=None if vis_left is None
++                else vis_left[query_start:query_end],
++                vis_right=None if vis_right is None
++                else vis_right[query_start:query_end],
++                vis_extra=vis_extra,
+             )
+             rocm_sparse_attn_prefill(
+                 q=q[query_start:query_end],
 --- a/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/attention.py
 +++ b/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/attention.py
 @@ -75,6 +75,15 @@
@@ -728,6 +897,124 @@
              num_warps=1,  # TODO: Tune this
          )
      return index_q_fp8, index_weights_out
+--- a/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
++++ b/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+@@ -168,6 +168,28 @@
+     hash_indices_table: torch.Tensor | None = None,
+     routed_scaling_factor: float = 1.0,
+ ):
++    # Vision-Exp supplies a per-token selection bias. The fused ROCm op accepts
++    # only one [experts] bias, so use the exact torch reference for this small
++    # multimodal routing case while keeping the text-only fast path untouched.
++    if (
++        scoring_func == "sqrtsoftplus"
++        and e_score_correction_bias is not None
++        and e_score_correction_bias.dim() == 2
++    ):
++        m = hidden_states.size(0)
++        topk_weights = torch.empty(
++            m, topk, dtype=torch.float32, device=hidden_states.device)
++        topk_ids = torch.empty(
++            m, topk,
++            dtype=torch.int32 if indices_type is None else indices_type,
++            device=hidden_states.device)
++        token_expert_indices = torch.empty(
++            m, topk, dtype=torch.int32, device=hidden_states.device)
++        return _topk_softplus_sqrt_torch(
++            topk_weights, topk_ids, token_expert_indices, gating_output,
++            renormalize, e_score_correction_bias, input_tokens,
++            hash_indices_table, routed_scaling_factor)
++
+     # The topk kernel dispatches dtype based on topk_ids (set by
+     # indices_type) and assumes input_tokens/hash_indices_table match.
+     if indices_type is not None:
+@@ -346,6 +368,10 @@
+         self.routed_scaling_factor = routed_scaling_factor
+         self.scoring_func = scoring_func
+         self._hash_indices_table = hash_indices_table
++        # Populated by the DeepSeek-V4 AMD model for Vision-Exp. Keeping these
++        # on the router lets the existing MoE runner retain its custom kernels.
++        self.vision_e_score_correction_bias: torch.Tensor | None = None
++        self.vision_vocab_size: int | None = None
+ 
+     @property
+     def routing_method_type(self) -> RoutingMethodType:
+@@ -367,17 +393,38 @@
+         input_ids: torch.Tensor | None = None,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         """Compute routing using fused top-k with bias."""
++        selection_bias = (
++            self.e_score_correction_bias.data
++            if self.e_score_correction_bias is not None
++            else None
++        )
++        safe_input_ids = input_ids
++        if (
++            self.vision_e_score_correction_bias is not None
++            and self.vision_vocab_size is not None
++            and input_ids is not None
++        ):
++            image_mask = input_ids >= self.vision_vocab_size
++            safe_input_ids = torch.where(
++                image_mask, torch.zeros_like(input_ids), input_ids)
++            text_bias = selection_bias
++            if text_bias is None:
++                text_bias = torch.zeros_like(
++                    self.vision_e_score_correction_bias)
++            selection_bias = torch.where(
++                image_mask.unsqueeze(-1),
++                self.vision_e_score_correction_bias.unsqueeze(0),
++                text_bias.unsqueeze(0),
++            )
+         topk_weights, topk_ids = fused_topk_bias(
+             hidden_states=hidden_states,
+             gating_output=router_logits,
+             scoring_func=self.scoring_func,
+-            e_score_correction_bias=self.e_score_correction_bias.data
+-            if self.e_score_correction_bias is not None
+-            else None,
++            e_score_correction_bias=selection_bias,
+             topk=self.top_k,
+             renormalize=self.renormalize,
+             indices_type=indices_type,
+-            input_tokens=input_ids,
++            input_tokens=safe_input_ids,
+             hash_indices_table=self._hash_indices_table,
+             routed_scaling_factor=self.routed_scaling_factor,
+         )
+--- a/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/registry.py
++++ b/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/registry.py
+@@ -99,6 +99,12 @@
+     "DeepseekV3ForCausalLM": ("deepseek_v2", "DeepseekV3ForCausalLM"),
+     "DeepseekV32ForCausalLM": ("deepseek_v2", "DeepseekV3ForCausalLM"),
+     "DeepseekV4ForCausalLM": ("vllm.models.deepseek_v4", "DeepseekV4ForCausalLM"),
++    # Vision-Exp currently declares the text architecture; launch it with
++    # --hf-overrides '{"architectures":["DeepseekV4VForConditionalGeneration"]}'.
++    "DeepseekV4VForConditionalGeneration": (
++        "vllm.models.deepseek_v4.vision_model",
++        "DeepseekV4VForConditionalGeneration",
++    ),
+     "Dots1ForCausalLM": ("dots1", "Dots1ForCausalLM"),
+     "Ernie4_5ForCausalLM": ("ernie45", "Ernie4_5ForCausalLM"),
+     "Ernie4_5_MoeForCausalLM": ("ernie45_moe", "Ernie4_5_MoeForCausalLM"),
+--- a/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/input_processor.py
++++ b/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/input_processor.py
+@@ -480,7 +480,14 @@
+             # Here we take the max of the two to determine if a token id is
+             # truly out-of-vocabulary.
+             model_vocab_size = model_config.get_vocab_size()
+-            if max_input_id > max(tokenizer.max_token_id, model_vocab_size - 1):
++            max_allowed_id = max(tokenizer.max_token_id, model_vocab_size - 1)
++            hf_config = model_config.hf_config
++            # Vision-Exp emits five sentinel ids [vocab_size, vocab_size + 4].
++            # They are replaced by multimodal embeddings before text lookup but
++            # remain visible to the LM for modality routing and image spans.
++            if int(getattr(hf_config, "vision_n_layers", 0) or 0) > 0:
++                max_allowed_id = max(max_allowed_id, model_vocab_size + 4)
++            if max_input_id > max_allowed_id:
+                 raise ValueError(f"Token id {max_input_id} is out of vocabulary")
+ 
+     def _validate_model_inputs(
 --- a/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/sparse_attn_indexer.py
 +++ b/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/sparse_attn_indexer.py
 @@ -514,7 +514,7 @@
@@ -2650,6 +2937,26 @@
          assert (
              len(
                  set(
+--- a/opt/venv/lib/python3.12/site-packages/vllm/config/speculative.py
++++ b/opt/venv/lib/python3.12/site-packages/vllm/config/speculative.py
+@@ -313,7 +313,16 @@
+             )
+         if hf_config.model_type == "deepseek_v4":
+             hf_config.model_type = "deepseek_mtp"
+-            n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
++            # DS4: the DSpark drafter is ONE predictor whose three stages are
++            # the checkpoint's mtp.{0,1,2} (see amd/dspark_mtp.py); it drafts a
++            # whole block per pass, so proposer steps reuse the same predictor.
++            # num_nextn_predict_layers only differs in how checkpoints DECLARE
++            # that drafter (0731: 1, Vision-Exp: 3). n_predict=1 keeps the
++            # num_speculative_tokens validation on the MTP-5 production shape;
++            # this callable runs on a freshly loaded draft config, so a user
++            # --hf-overrides on the target cannot reach it.
++            n_predict = 1 if getattr(
++                hf_config, "num_nextn_predict_layers", None) else None
+             hf_config.update(
+                 {"n_predict": n_predict, "architectures": ["DeepSeekV4MTPModel"]}
+             )
 --- a/opt/venv/lib/python3.12/site-packages/vllm/v1/kv_offload/tiering/factory.py
 +++ b/opt/venv/lib/python3.12/site-packages/vllm/v1/kv_offload/tiering/factory.py
 @@ -69,3 +69,11 @@

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/odl_mq.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/odl_mq.py
@@ -48,7 +48,6 @@ _LIB_CANDIDATES = [
     os.environ.get("ODL_MQ_LIB", ""),
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "libodl_tb5.so.0"),
     os.path.expanduser("~/.cache/odinlink/build/lib/libodl_tb5.so.0"),
-    "/var/home/alex/.cache/odinlink/build/lib/libodl_tb5.so.0",
     "libodl_tb5.so.0",
 ]
 

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/amd/dspark_mtp.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/amd/dspark_mtp.py
@@ -1178,17 +1178,20 @@ class DSparkMultiTokenPredictor(nn.Module):
             else [torch.cuda.Stream() for _ in range(3)]
         )
 
+        # Exactly ONE predictor layer, always. The checkpoint's mtp.{0,1,2}
+        # stages are INTERNAL to this layer (mtp_blocks, each registering its
+        # own KV cache as model.layers.{43,44,45}); load_weights routes every
+        # mtp.* weight into it. num_nextn_predict_layers only differs in how
+        # the checkpoint DECLARES the same three-stage drafter (0731: 1,
+        # Vision-Exp: 3) -- one predictor per declared layer would register
+        # the stage KV-cache names once per copy ("Duplicate layer name").
         self.layers = torch.nn.ModuleDict(
             {
-                str(idx): DSparkMultiTokenPredictorLayer(
+                str(self.mtp_start_layer_idx): DSparkMultiTokenPredictorLayer(
                     vllm_config,
                     self.topk_indices_buffer,
-                    f"{prefix}.layers.{idx}",
+                    f"{prefix}.layers.{self.mtp_start_layer_idx}",
                     aux_stream_list=aux_stream_list,
-                )
-                for idx in range(
-                    self.mtp_start_layer_idx,
-                    self.mtp_start_layer_idx + self.num_mtp_layers,
                 )
             }
         )

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/mm_preprocess.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/mm_preprocess.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Image preprocessing and multimodal processor for DeepSeek-V4-Flash-Vision-Exp.
+
+Ported from the reference ``inference/image_processor.py`` in the checkpoint.
+Every formula here is load-bearing: the aligner emits one embedding per 3x3
+patch block and those embeddings are scattered into an "N-layout" token grid, so
+any drift in the resize solver, the token count, or the permutation puts image
+features in the wrong positions.
+
+One structural note. The reference computes a leading pad of
+``3 - start_pos % 4`` so the first grid token lands on a multiple of 4 (the C4
+KV compressor's block). That makes an image's token count depend on its absolute
+offset in the prompt, which vLLM's ``_get_prompt_updates`` cannot express -- its
+replacement callables receive only ``item_idx``. We therefore do the whole
+tokenize-and-expand in ``_call_hf_processor``, where offsets are known, and use
+``_get_prompt_updates`` only to let the framework re-discover the already-placed
+blocks so it can record placeholder ranges.
+"""
+
+import math
+from collections.abc import Mapping, Sequence
+
+import numpy as np
+import torch
+from PIL import Image, ImageOps
+from transformers import BatchFeature
+
+from vllm.multimodal import MULTIMODAL_REGISTRY  # noqa: F401  (re-export use)
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItems
+from vllm.multimodal.parse import ImageProcessorItems, MultiModalDataItems
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    PromptReplacement,
+    PromptUpdate,
+)
+
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+COMPRESS_PAD_TO = 4
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+
+def compress_pad_for_start(start_pos: int) -> int:
+    """Leading pads that align the first image-grid token to a C4 block."""
+    return COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+
+
+def grid_tokens(best_height, best_width, patch_size, downsample_ratio):
+    n_llm_h = math.ceil((best_height // patch_size) / downsample_ratio)
+    n_llm_w = math.ceil((best_width // patch_size) / downsample_ratio)
+    num_tokens = n_llm_h * (n_llm_w + 1) + 2
+    if n_llm_h % 2 == 1:
+        num_tokens += n_llm_w + 1
+    num_tokens += (n_llm_h + 1) // 2 * (n_llm_w + 1) % 2 * 2
+    return n_llm_h, n_llm_w, num_tokens
+
+
+def solve_resize_ratio(height, width, patch_size, downsample_ratio, max_n_token):
+    r = height / width
+    max_w_float = math.sqrt((max_n_token - 2) / r + 0.25) - 0.5
+    max_h_float = max_w_float * r
+    if max_w_float < 1.0:
+        max_w = 1
+        max_h = (max_n_token - 2) // (max_w + 1)
+        if max_h % 2 == 1:
+            max_h -= 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    elif max_h_float < 2.0:
+        max_h = 2
+        max_w = ((max_n_token - 2) // max_h) - 1
+        assert max_w > 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    else:
+        max_w = math.floor(max_w_float)
+        max_h = math.floor(max_h_float)
+        if max_h % 2 == 1:
+            max_h -= 1
+        beta = min(max_w * patch_size * downsample_ratio / width,
+                   max_h * patch_size * downsample_ratio / height)
+        best_width = math.floor(width * beta / patch_size) * patch_size
+        best_height = math.floor(height * beta / patch_size) * patch_size
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio)
+    return n_llm_h, n_llm_w, best_height, best_width, num_tokens
+
+
+def safe_resize(height, width, best_height, best_width, patch_size,
+                downsample_ratio, max_n_token):
+    max_n_token -= COMPRESS_PAD_TO - 1
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio)
+    budget = max_n_token
+    while num_tokens > max_n_token:
+        n_llm_h, n_llm_w, best_height, best_width, num_tokens = solve_resize_ratio(
+            height, width, patch_size, downsample_ratio, budget)
+        budget -= 1
+    return n_llm_h, n_llm_w, best_height, best_width
+
+
+def image_token_count_for_size(width: int, height: int, start_pos: int,
+                               patch_size: int = 14,
+                               downsample_ratio: int = 3,
+                               max_n_token: int = 384,
+                               min_pixels: int = 147456,
+                               max_wh_ratio: int | None = 8) -> int:
+    """Return the reference image-block size without decoding image pixels."""
+    if max_wh_ratio is not None and width > height * max_wh_ratio:
+        width = height * max_wh_ratio
+    if 0 < width * height < min_pixels:
+        ratio = (min_pixels / (width * height)) ** 0.5
+        width = int(width * ratio)
+        height = int(height * ratio)
+    best_width = math.ceil(width / patch_size) * patch_size
+    best_height = math.ceil(height / patch_size) * patch_size
+    _, _, best_height, best_width = safe_resize(
+        height, width, best_height, best_width, patch_size,
+        downsample_ratio, max_n_token)
+    _, _, grid_count = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio)
+    return compress_pad_for_start(start_pos) + grid_count
+
+
+def preprocess_image(image: Image.Image, cfg):
+    """PIL image -> (patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w)."""
+    p = cfg.vision_patch_size
+    image = image.convert("RGB")
+    width, height = image.size
+    if cfg.vision_max_wh_ratio is not None and width > height * cfg.vision_max_wh_ratio:
+        width = height * cfg.vision_max_wh_ratio
+    if 0 < width * height < cfg.vision_min_pixels:
+        ratio = (cfg.vision_min_pixels / (width * height)) ** 0.5
+        width = int(width * ratio)
+        height = int(height * ratio)
+    best_width = math.ceil(width / p) * p
+    best_height = math.ceil(height / p) * p
+    n_llm_h, n_llm_w, best_height, best_width = safe_resize(
+        height, width, best_height, best_width, p,
+        cfg.vision_downsample_ratio, cfg.vision_max_n_token)
+    n_vit_h, n_vit_w = best_height // p, best_width // p
+    if (cfg.vision_max_wh_ratio is not None
+            and image.width >= cfg.vision_max_wh_ratio * image.height):
+        image = image.resize((best_width, best_height))
+    else:
+        image = ImageOps.pad(image, (best_width, best_height), color=(127, 127, 127))
+    x = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+    x = ((x - 0.5) / 0.5).to(torch.bfloat16)
+    patches = x.reshape(3, n_vit_h, p, n_vit_w, p).permute(1, 3, 0, 2, 4).reshape(
+        n_vit_h * n_vit_w, 3, p, p)
+    return patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+
+def build_image_block(n_llm_h: int, n_llm_w: int, start_pos: int):
+    """Token types in emission order, plus the aligner-row order for IMAGE slots."""
+    compress_pad = compress_pad_for_start(start_pos)
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = rows // 2 * row_len % 2 * 2
+    types = torch.tensor(
+        ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h
+        + [IMAGE_PAD] * (row_len * pad_h), dtype=torch.int64)
+    order = torch.arange(rows * row_len).view(rows // 2, 2, row_len).transpose(1, 2).reshape(-1)
+    image_idx = torch.full((rows * row_len,), -1, dtype=torch.int64)
+    image_idx.view(rows, row_len)[:n_llm_h, :n_llm_w] = torch.arange(
+        n_llm_h * n_llm_w).view(n_llm_h, n_llm_w)
+    perm = image_idx[order]
+    perm = perm[perm >= 0]
+    types = torch.cat([
+        torch.full((compress_pad,), IMAGE_PAD, dtype=torch.int64),
+        torch.tensor([IMAGE_START]),
+        types[order],
+        torch.full((pad_last,), IMAGE_PAD, dtype=torch.int64),
+        torch.tensor([IMAGE_END]),
+    ])
+    return types, perm
+
+
+def max_block_tokens(cfg) -> int:
+    """Worst-case tokens one image can occupy, for profiling."""
+    return cfg.vision_max_n_token
+
+
+class DeepseekV4VProcessingInfo(BaseProcessingInfo):
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        return {"image": None}
+
+    def get_hf_config(self):
+        return self.ctx.model_config.hf_config
+
+    def get_num_image_tokens(self, *, image_width: int, image_height: int) -> int:
+        cfg = self.get_hf_config()
+        img = Image.new("RGB", (image_width, image_height))
+        _, _, _, n_llm_h, n_llm_w = preprocess_image(img, cfg)
+        _, _, n = grid_tokens(
+            n_llm_h * cfg.vision_downsample_ratio * cfg.vision_patch_size,
+            n_llm_w * cfg.vision_downsample_ratio * cfg.vision_patch_size,
+            cfg.vision_patch_size, cfg.vision_downsample_ratio)
+        # +3 covers the worst-case position-dependent leading pad.
+        return n + COMPRESS_PAD_TO - 1
+
+
+class DeepseekV4VDummyInputsBuilder(BaseDummyInputsBuilder[DeepseekV4VProcessingInfo]):
+
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return IMAGE_PLACEHOLDER * mm_counts.get("image", 0)
+
+    def get_dummy_mm_data(self, seq_len: int, mm_counts: Mapping[str, int],
+                          mm_options=None):
+        cfg = self.info.get_hf_config()
+        # Largest image that still fits the token budget, so profiling is worst-case.
+        side = int(math.sqrt(cfg.vision_min_pixels)) * 2
+        return {"image": self._get_dummy_images(
+            width=side, height=side, num_images=mm_counts.get("image", 0))}
+
+
+class DeepseekV4VMultiModalProcessor(BaseMultiModalProcessor[DeepseekV4VProcessingInfo]):
+
+    def _cached_apply_hf_processor(self, inputs, timing_ctx):
+        """Always take the uncached, whole-prompt path.
+
+        The per-item processing cache assumes an item's expansion is invariant
+        of the prompt it lands in. Ours is not: the leading pad is
+        ``3 - start_pos % 4``, so the same image expands differently depending
+        on its offset. Under the cached path vLLM also processes text and
+        images separately, which leaves our expansion unable to see the images
+        at all (out_mm_kwargs comes back with no modalities).
+        """
+        return self._apply_hf_processor(inputs, timing_ctx)
+
+    def _call_hf_processor(self, prompt, mm_data, mm_kwargs, tok_kwargs) -> BatchFeature:
+        cfg = self.info.get_hf_config()
+        tokenizer = self.info.get_tokenizer()
+        image_token_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+        vocab_size = cfg.vocab_size
+
+        # _get_hf_mm_data keys this by the HF processor convention ("images"),
+        # not by the vLLM modality name ("image"). Reading the wrong key here
+        # silently takes the text-only branch and emits no multimodal fields at
+        # all, which surfaces much later as "Modality 'image' not found".
+        images = mm_data.get("images")
+        if images is None:
+            images = mm_data.get("image") or []
+        if not isinstance(images, (list, tuple)):
+            images = [images]
+
+        prompt_tokens = tokenizer.encode(prompt, add_special_tokens=False)
+
+        # vLLM calls the processor with the text prompt and no images during
+        # profiling and for text-only requests. The placeholder must then be
+        # left untouched: there is nothing to expand it into.
+        if not images:
+            return BatchFeature(
+                {"input_ids": torch.tensor([prompt_tokens], dtype=torch.int64)})
+
+        tokens: list[int] = []
+        all_patches, all_types, all_perm = [], [], []
+        n_vit, n_llm, blocks = [], [], []
+        it = iter(images)
+        for tok in prompt_tokens:
+            if tok != image_token_id:
+                tokens.append(tok)
+                continue
+            patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = preprocess_image(next(it), cfg)
+            types, perm = build_image_block(n_llm_h, n_llm_w, len(tokens))
+            block = (vocab_size + types).tolist()
+            tokens += block
+            all_patches.append(patches)
+            all_types.append(types)
+            all_perm.append(perm)
+            n_vit.append([n_vit_h, n_vit_w])
+            n_llm.append([n_llm_h, n_llm_w])
+            blocks.append(torch.tensor(block, dtype=torch.int64))
+
+        out = {"input_ids": torch.tensor([tokens], dtype=torch.int64)}
+        if all_patches:
+            out.update(
+                patches=torch.cat(all_patches, dim=0),
+                patch_sizes=torch.tensor([p.shape[0] for p in all_patches]),
+                types=torch.cat(all_types, dim=0),
+                type_sizes=torch.tensor([t.shape[0] for t in all_types]),
+                perm=torch.cat(all_perm, dim=0),
+                perm_sizes=torch.tensor([p.shape[0] for p in all_perm]),
+                n_vit=torch.tensor(n_vit, dtype=torch.int64),
+                n_llm=torch.tensor(n_llm, dtype=torch.int64),
+                token_blocks=torch.cat(blocks, dim=0),
+            )
+        return BatchFeature(out)
+
+    def _get_mm_fields_config(self, hf_inputs, hf_processor_mm_kwargs
+                              ) -> Mapping[str, MultiModalFieldConfig]:
+        patch_sizes = hf_inputs.get("patch_sizes", torch.empty(0, dtype=torch.int64))
+        type_sizes = hf_inputs.get("type_sizes", torch.empty(0, dtype=torch.int64))
+        perm_sizes = hf_inputs.get("perm_sizes", torch.empty(0, dtype=torch.int64))
+        return dict(
+            patches=MultiModalFieldConfig.flat_from_sizes("image", patch_sizes),
+            patch_sizes=MultiModalFieldConfig.batched("image"),
+            types=MultiModalFieldConfig.flat_from_sizes("image", type_sizes),
+            type_sizes=MultiModalFieldConfig.batched("image"),
+            perm=MultiModalFieldConfig.flat_from_sizes("image", perm_sizes),
+            perm_sizes=MultiModalFieldConfig.batched("image"),
+            n_vit=MultiModalFieldConfig.batched("image"),
+            n_llm=MultiModalFieldConfig.batched("image"),
+            token_blocks=MultiModalFieldConfig.flat_from_sizes("image", type_sizes),
+        )
+
+    def _get_prompt_updates(self, mm_items, hf_processor_mm_kwargs,
+                            out_mm_kwargs: MultiModalKwargsItems) -> Sequence[PromptUpdate]:
+        tokenizer = self.info.get_tokenizer()
+        image_token_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+
+        def replacement(item_idx: int):
+            item = out_mm_kwargs["image"][item_idx]
+            return item["token_blocks"].data.tolist()
+
+        return [PromptReplacement(modality="image", target=[image_token_id],
+                                  replacement=replacement)]

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/vision.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/vision.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vision tower and aligner for DeepSeek-V4-Flash-Vision-Exp.
+
+Faithful port of the reference implementation shipped in the checkpoint at
+``inference/vision.py``. Deliberately built from plain ``torch.nn`` modules and
+``F.scaled_dot_product_attention``: the tower and aligner are BF16 in the
+checkpoint (259 + 4 tensors, no scale tensors), and DeepseekV4FP8Config only
+attaches quant methods to ``LinearBase``/``RoutedExperts``, so plain modules can
+never be quantized by accident. This matches the deepseek_ocr2 precedent.
+
+The tower runs one image per call with full bidirectional attention and 2D RoPE;
+there is no CLS token, no learned position embedding, and no windowing.
+"""
+
+from functools import lru_cache
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+@lru_cache(8)
+def _cos_sin(n_h: int, n_w: int, dim: int, theta: float):
+    """2D RoPE tables: the first half of each head's rotary block is driven by
+    the patch row, the second half by the column."""
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    hpos = torch.arange(n_h).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w).unsqueeze(0).expand(n_h, n_w)
+    freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float() * inv_freq
+    freqs = freqs.flatten(1)
+    return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
+
+
+def _apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
+
+
+class VisionRMSNorm(nn.Module):
+    # eps is 1e-6 here, NOT the LM's rms_norm_eps (1e-20): the reference Block
+    # constructs RMSNorm(dim) with no eps argument, taking this default.
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+class PatchEmbed(nn.Module):
+    def __init__(self, dim: int, patch_size: int):
+        super().__init__()
+        self.proj = nn.Linear(3 * patch_size**2, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Channel-major flatten: index = c*patch^2 + py*patch + px.
+        return self.proj(x.flatten(1))
+
+
+class VisionAttention(nn.Module):
+    def __init__(self, dim: int, n_heads: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wqkv = nn.Linear(dim, 3 * dim)
+        self.wo = nn.Linear(dim, dim)
+
+    def forward(self, x, cos, sin):
+        n = x.size(0)
+        q, k, v = (t.view(n, self.n_heads, self.head_dim)
+                   for t in self.wqkv(x).chunk(3, dim=-1))
+        q = _apply_rotary(q, cos, sin)
+        k = _apply_rotary(k, cos, sin)
+        o = F.scaled_dot_product_attention(
+            q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1))
+        return self.wo(o.transpose(0, 1).reshape(n, -1))
+
+
+class VisionMLP(nn.Module):
+    def __init__(self, dim: int, inter_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, 2 * inter_dim, bias=False)
+        self.w2 = nn.Linear(inter_dim, dim, bias=False)
+
+    def forward(self, x):
+        gate, up = self.w1(x).chunk(2, dim=-1)
+        return self.w2(F.silu(gate) * up)
+
+
+class VisionBlock(nn.Module):
+    def __init__(self, dim: int, n_heads: int, inter_dim: int):
+        super().__init__()
+        self.norm1 = VisionRMSNorm(dim)
+        self.attn = VisionAttention(dim, n_heads)
+        self.norm2 = VisionRMSNorm(dim)
+        self.mlp = VisionMLP(dim, inter_dim)
+
+    def forward(self, x, cos, sin):
+        x = x + self.attn(self.norm1(x), cos, sin)
+        return x + self.mlp(self.norm2(x))
+
+
+class DeepseekV4ViT(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        dim = config.vision_dim
+        n_heads = config.vision_n_heads
+        self.rope_dim = dim // n_heads // 2
+        self.rope_theta = config.vision_rope_theta
+        self.patch_embed = PatchEmbed(dim, config.vision_patch_size)
+        self.blocks = nn.ModuleList([
+            VisionBlock(dim, n_heads, config.vision_inter_dim)
+            for _ in range(config.vision_n_layers)
+        ])
+        self.norm = VisionRMSNorm(dim)
+
+    def forward(self, patches: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        x = self.patch_embed(patches)
+        cos, sin = _cos_sin(n_h, n_w, self.rope_dim, self.rope_theta)
+        # _cos_sin builds on CPU and is lru_cached; move to the activation device.
+        cos = cos.to(x.device)
+        sin = sin.to(x.device)
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        return self.norm(x)
+
+
+class DeepseekV4Aligner(nn.Module):
+    """3x3 space-to-depth (pixel-unshuffle) then a 2-layer GELU MLP to LM width."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.r = config.vision_downsample_ratio
+        self.w1 = nn.Linear(config.vision_dim * self.r**2, config.hidden_size)
+        self.w2 = nn.Linear(config.hidden_size, config.hidden_size)
+
+    def forward(self, x: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        r = self.r
+        x = x.view(n_h, n_w, -1).permute(2, 0, 1)
+        # Zero-pad right/bottom to a multiple of r, matching the reference.
+        x = F.pad(x, (0, -n_w % r, 0, -n_h % r))
+        x = F.unfold(x.unsqueeze(0), r, stride=r).squeeze(0).transpose(0, 1)
+        return self.w2(F.gelu(self.w1(x)))

--- a/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/vision_model.py
+++ b/container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/vision_model.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multimodal wrapper for DeepSeek-V4-Flash-Vision-Exp.
+
+Wraps the existing text-only DeepseekV4ForCausalLM with the checkpoint's ViT +
+aligner and the sentinel-block embedding layout.
+
+The image block is emitted as out-of-vocabulary token ids (vocab_size + type,
+i.e. 129280..129284). Those ids never index the embedding table -- the LM reads
+them for MoE routing and attention visibility -- so every position in the block
+is a "multimodal" position and embed_multimodal returns the whole block: the
+learned image_start/pad/newline/end vectors in their slots and aligner outputs
+at IMAGE slots, permuted into the N-layout by `perm`.
+"""
+
+import os
+from collections.abc import Iterable, Mapping
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+    SupportsPP,
+)
+from vllm.model_executor.models.module_mapping import MultiModelKeys
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.sequence import IntermediateTensors
+
+from vllm.models.deepseek_v4.mm_preprocess import (
+    IMAGE,
+    IMAGE_END,
+    IMAGE_PLACEHOLDER,
+    IMAGE_START,
+    DeepseekV4VDummyInputsBuilder,
+    DeepseekV4VMultiModalProcessor,
+    DeepseekV4VProcessingInfo,
+)
+from vllm.models.deepseek_v4.vision import DeepseekV4Aligner, DeepseekV4ViT
+
+
+# DS4_VISION_SPAN_ATTN=0 disables span-bidirectional attention (falls back to
+# fully causal image spans, the pre-fidelity behavior). Latched at import.
+_DS4_VISION_SPAN_ATTN = os.environ.get("DS4_VISION_SPAN_ATTN", "1") != "0"
+
+
+def compute_image_visibility(
+    input_ids: torch.Tensor, vocab_size: int, max_image_tokens: int
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Per-token (left, right) visible distances within [IMAGE_START..IMAGE_END]
+    spans, matching the reference ``get_image_visible`` on a flat token batch.
+
+    Spans consist entirely of sentinel ids (>= vocab_size), so no request
+    segmentation is needed: START/END pair up in flat order. A span fragment
+    truncated by a chunked-prefill boundary (unmatched START or END) is zeroed
+    -> those positions fall back to plain causal SWA, which is also what every
+    already-processed chunk used. Fully async: no device sync, no data-
+    dependent host branch; all-text batches yield all-zero left/right, which
+    the combine kernel maps to the exact causal window.
+    """
+    if input_ids.numel() == 0:
+        return None
+    ids = input_ids
+    n = ids.shape[0]
+    idx = torch.arange(n, dtype=torch.int32, device=ids.device)
+    is_start = ids == vocab_size + IMAGE_START
+    is_end = ids == vocab_size + IMAGE_END
+    cs = is_start.cumsum(0)
+    ce = is_end.cumsum(0)
+    valid = (cs > ce) | is_end
+    starts = torch.where(is_start, idx, 0).cummax(0)[0]
+    left = (idx - starts) * valid
+    ends = torch.where(is_end, idx, n).flip(0).cummin(0)[0].flip(0)
+    right = (ends - idx) * valid
+    # Truncated fragments: a span with no END in this batch (ends == n), or an
+    # END with no earlier START (more ENDs than STARTs seen).
+    bad = (valid & (ends == n)) | (is_end & (cs < ce))
+    left = torch.where(bad, 0, left).clamp_(max=max_image_tokens - 1)
+    right = torch.where(bad, 0, right).clamp_(max=max_image_tokens)
+    return left.to(torch.int32).contiguous(), right.to(torch.int32).contiguous()
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    DeepseekV4VMultiModalProcessor,
+    info=DeepseekV4VProcessingInfo,
+    dummy_inputs=DeepseekV4VDummyInputsBuilder,
+)
+class DeepseekV4VForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
+    # The LM's MoE gate selects `bias_vl` over `bias` per position and the hash
+    # layers index tid2eid by token id, so the raw ids must reach forward().
+    requires_raw_input_tokens = True
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "layers.": "language_model.layers.",
+            "embed.": "language_model.embed.",
+            "norm.": "language_model.norm.",
+            "hc_head": "language_model.hc_head",
+            "mtp.": "language_model.mtp.",
+        },
+        orig_to_new_suffix={"head.weight": "language_model.head.weight"},
+    )
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return IMAGE_PLACEHOLDER
+        return None
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        self.config = config
+
+        with self._mark_tower_model(vllm_config, "image"):
+            # Plain nn.Modules: never handed a quant_config, so the BF16 tower
+            # cannot be picked up by DeepseekV4FP8Config.
+            self.vision = DeepseekV4ViT(config)
+            self.aligner = DeepseekV4Aligner(config)
+            hidden = config.hidden_size
+            self.image_start = nn.Parameter(torch.empty(hidden))
+            self.image_pad = nn.Parameter(torch.empty(hidden))
+            self.image_newline = nn.Parameter(torch.empty(hidden))
+            self.image_end = nn.Parameter(torch.empty(hidden))
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                architectures=["DeepseekV4ForCausalLM"],
+            )
+
+        # 129280..129284 are >= vocab_size; this makes the default
+        # embed_input_ids mask them to 0 before the text-embedding gather.
+        vocab_size = config.vocab_size
+        self.configure_mm_token_handling(
+            vocab_size, [vocab_size + i for i in range(5)])
+
+        # The MTP proposer's load_model copies config.image_token_index into
+        # the draft config (EAGLE-style drafters mask by it; nothing in this
+        # tree reads it back, but the copy itself requires the attribute).
+        # Point it at the IMAGE sentinel slot.
+        config.image_token_index = vocab_size + IMAGE
+
+    def _encode_one(self, patches, n_vit_h, n_vit_w, types, perm):
+        feats = self.vision(patches, n_vit_h, n_vit_w)
+        embeds = self.aligner(feats, n_vit_h, n_vit_w)[perm]
+        params = torch.stack([
+            self.image_start, self.image_pad, self.image_pad,
+            self.image_newline, self.image_end,
+        ]).to(embeds.dtype)
+        block = params[types]
+        block[types == IMAGE] = embeds.to(block.dtype)
+        return block
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | None:
+        patches = kwargs.get("patches")
+        if patches is None:
+            return None
+        patch_sizes = kwargs["patch_sizes"]
+        types = kwargs["types"]
+        type_sizes = kwargs["type_sizes"]
+        perm = kwargs["perm"]
+        perm_sizes = kwargs["perm_sizes"]
+        n_vit = kwargs["n_vit"]
+
+        def _flat(x):
+            return torch.cat([t.flatten() for t in x]) if isinstance(x, (list, tuple)) else x.flatten()
+
+        patch_sizes = _flat(patch_sizes).tolist()
+        type_sizes = _flat(type_sizes).tolist()
+        perm_sizes = _flat(perm_sizes).tolist()
+        if isinstance(patches, (list, tuple)):
+            patches = torch.cat([p for p in patches], dim=0)
+        if isinstance(types, (list, tuple)):
+            types = torch.cat([t.flatten() for t in types], dim=0)
+        if isinstance(perm, (list, tuple)):
+            perm = torch.cat([p.flatten() for p in perm], dim=0)
+        if isinstance(n_vit, (list, tuple)):
+            n_vit = torch.cat([n.reshape(-1, 2) for n in n_vit], dim=0)
+        n_vit = n_vit.reshape(-1, 2)
+
+        device = next(self.vision.parameters()).device
+        out, po, to, ro = [], 0, 0, 0
+        for i, np_ in enumerate(patch_sizes):
+            ts, rs = type_sizes[i], perm_sizes[i]
+            out.append(self._encode_one(
+                patches[po:po + np_].to(device),
+                int(n_vit[i][0]), int(n_vit[i][1]),
+                types[to:to + ts].to(device),
+                perm[ro:ro + rs].to(device),
+            ))
+            po += np_; to += ts; ro += rs
+        return out
+
+    def forward(self, input_ids, positions, intermediate_tensors=None,
+                inputs_embeds=None, **kwargs):
+        # Reference fidelity: attention is bidirectional within each image
+        # span. Publish per-token span visibility for this step; the ROCm
+        # sparse-SWA prefill combine consumes it. Skipped on pure-decode
+        # steps (queries there are text; avoids per-step kernels on the hot
+        # path) and under stream capture (decode-only graphs never need it).
+        # A fresh ForwardContext is created every step, so absence == absent.
+        if (_DS4_VISION_SPAN_ATTN and input_ids is not None
+                and not torch.cuda.is_current_stream_capturing()):
+            fc = get_forward_context()
+            md = fc.attn_metadata
+            has_prefill = False
+            if isinstance(md, dict):
+                # Only the sparse-SWA metadata carries num_prefills; find one.
+                # Unknown shape (no SWA entry) computes anyway — safe, async.
+                has_prefill = True
+                for v in md.values():
+                    n = getattr(v, "num_prefills", None)
+                    if n is not None:
+                        has_prefill = n > 0
+                        break
+            if has_prefill:
+                vis = compute_image_visibility(
+                    input_ids, self.config.vocab_size,
+                    self.config.vision_max_n_token)
+                if vis is not None:
+                    fc.ds4_image_visibility = (
+                        vis[0], vis[1], int(self.config.vision_max_n_token))
+        return self.language_model(
+            input_ids=input_ids, positions=positions,
+            intermediate_tensors=intermediate_tensors, inputs_embeds=inputs_embeds)
+
+    def compute_logits(self, hidden_states, *args, **kwargs):
+        return self.language_model.compute_logits(hidden_states, *args, **kwargs)
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        # The runner probes the TARGET model for this DSpark stash hook via
+        # getattr(..., lambda: None); without the delegation it silently
+        # falls back to the 4096-wide sampled hiddens and the drafter's
+        # 3-layer (12288-wide) input buffer copy fails.
+        return self.language_model.get_mtp_target_hidden_states()
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            connector="aligner",
+            tower_model="vision",
+        )

--- a/host/ds4-cluster-down.sh
+++ b/host/ds4-cluster-down.sh
@@ -23,7 +23,7 @@ rm -f "$PIDFILE"
 sleep 2
 
 # The bracket keeps this grep from matching its own command line.
-for p in $(ps -eo pid,cmd --no-headers | grep "bin/[v]llm serve deepseek" | awk '{print $1}'); do
+for p in $(ps -eo pid,cmd --no-headers | grep "bin/[v]llm serve" | awk '{print $1}'); do
   echo "[cluster-down] reaping vllm serve pid=$p"
   kill "$p" 2>/dev/null; sleep 3
   kill -0 "$p" 2>/dev/null && { kill -9 "$p" 2>/dev/null; sleep 2; }

--- a/host/ds4-cluster-env.ib.sh
+++ b/host/ds4-cluster-env.ib.sh
@@ -35,7 +35,7 @@ export DS4_IB_AR2_HCA=${DS4_IB_AR2_HCA:-mlx4}
 
 # Live profiling: enables /start_profile & /stop_profile API endpoints; traces
 # land in ~/vllm-profiles (shared into the container). Inert unless invoked.
-export VLLM_TORCH_PROFILER_DIR=/home/alex/vllm-profiles
+export VLLM_TORCH_PROFILER_DIR=$HOME/vllm-profiles
 export VLLM_SERVER_DEV_MODE=1
 # Single-kernel tiny-batch MoE routing (5 launches -> 1; ~8ms/step CPU).
 export DS4_TINY_ROUTING=1

--- a/host/ds4-cluster-env.sh
+++ b/host/ds4-cluster-env.sh
@@ -79,6 +79,10 @@ export DS4_MTP_CAPTURE=1
 # bounds win_kv, [n_stages, max_seqs, window, head_dim] bf16 = 3.1 MB at 8,
 # 25 MB at 64. Keep this at or above the highest concurrency you serve.
 export DS4_MTP_MAXSEQS=${DS4_MTP_MAXSEQS:-64}
+# DS4_VISION_SPAN_ATTN=1: with a Vision-Exp checkpoint, attention is bidirectional inside
+# each image span, as in the reference model; 0 keeps image spans causal.
+# No effect on the text checkpoint.
+export DS4_VISION_SPAN_ATTN=${DS4_VISION_SPAN_ATTN:-1}
 # propagate DS4_* to box2 ray workers (not in ray's default copy prefixes)
 export VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY=DS4_
 # Blocking (interrupt-based) GPU waits instead of busy-poll.

--- a/host/ds4-cluster-restart.sh
+++ b/host/ds4-cluster-restart.sh
@@ -75,12 +75,12 @@ rm -f "$PIDFILE"
 sleep 4
 
 # The bracket keeps this grep from matching its own command line.
-for p in $(ps -eo pid,cmd --no-headers | grep "bin/[v]llm serve deepseek" | awk '{print $1}'); do
+for p in $(ps -eo pid,cmd --no-headers | grep "bin/[v]llm serve" | awk '{print $1}'); do
   echo "   reaping stranded vllm serve pid=$p"
   kill "$p" 2>/dev/null; sleep 3
   kill -0 "$p" 2>/dev/null && { kill -9 "$p" 2>/dev/null; sleep 2; }
 done
-residual=$(ps -eo cmd --no-headers | grep -c "bin/[v]llm serve deepseek")
+residual=$(ps -eo cmd --no-headers | grep -c "bin/[v]llm serve")
 [ "$residual" -eq 0 ] || { echo "!! $residual vllm serve process(es) still alive -- aborting"; exit 1; }
 
 inbox 'ray stop --force >/dev/null 2>&1' >/dev/null 2>&1
@@ -168,6 +168,6 @@ else
   rdma=$(grep -aoE "odl_ar2: rank[0-9] ready[^\"]*" "$SERVE_LOG" 2>/dev/null | head -1)
   echo "   fast AR: ${rdma:-!! odl_ar2 NOT ready -- decode all-reduce is on the slow path}"
 fi
-echo "   vllm serve procs: $(ps -eo cmd --no-headers | grep -c 'bin/[v]llm serve deepseek') (want 1)"
+echo "   vllm serve procs: $(ps -eo cmd --no-headers | grep -c 'bin/[v]llm serve') (want 1)"
 echo "   ray idle workers: $(ps -eo cmd --no-headers | grep -c '[r]ay::IDLE')"
 echo "   MemAvailable: $(awk '/MemAvailable/{printf "%d", $2/1024}' /proc/meminfo)MB"

--- a/host/ds4-config.yaml
+++ b/host/ds4-config.yaml
@@ -2,7 +2,7 @@
 # Deployed as ~/ds4-config.yaml on box1 (the ray head); the cluster scripts
 # read it via `eval "$("$HOME/ds4-config")"`. Flat key: value only -- parsed
 # by ds4-config with the Python stdlib, no pyyaml.
-model: deepseek-ai/DeepSeek-V4-Flash-0731   # HF id (auto-downloaded to the HF cache) or a local path; weights needed on BOTH boxes
+model: deepseek-ai/DeepSeek-V4-Flash-0731   # HF id (auto-downloaded to the HF cache) or a local path; weights needed on BOTH boxes. For image input point this at deepseek-ai/DeepSeek-V4-Flash-Vision-Exp instead -- the launcher detects a vision checkpoint (README "Vision")
 transport: odl         # odl | tcp -- which ds4-cluster-env.<transport>.sh the cluster sources; odl is the fabric, tcp is the fallback for bring-up debugging
 head_ip: 192.168.100.1
 worker_ip: 192.168.100.2

--- a/host/ds4-ib-config.yaml
+++ b/host/ds4-ib-config.yaml
@@ -1,21 +1,21 @@
-# InfiniBand-transport test profile: the serving Vision-Exp stack with the
-# TP collectives moved from OdinLink to RCCL-over-IB (ConnectX-3 mlx4 fabric).
-# Start explicitly with:
-#   DS4_CONFIG_PATH="$HOME/ds4-ib-config.yaml" "$HOME/ds4-cluster-restart.sh"
-# ds4-vision-config.yaml (transport: odl) remains the boot default/rollback.
-# Same flat key: value format as ds4-config.yaml, parsed by ds4-config.
-model: /home/alex/ds4-vision   # local Vision-Exp checkout; weights needed on BOTH boxes
-hf_overrides: {"architectures":["DeepseekV4VForConditionalGeneration"],"num_nextn_predict_layers":1}
+# InfiniBand-transport variant of ds4-config.yaml: the same cluster with the
+# TP collectives on RCCL-over-IB plus the ib_ar2 decode all-reduce (a mlx4 /
+# ConnectX-3 fabric between the boxes) instead of the OdinLink Thunderbolt
+# fabric. Deploy it AS ~/ds4-config.yaml on box1 (the scripts read only that
+# file); the keys are the same as ds4-config.yaml, only transport/rdma_hca differ.
+# Same flat key: value format, parsed by ds4-config.
+model: deepseek-ai/DeepSeek-V4-Flash-0731   # HF id or a local path; weights needed on BOTH boxes (deepseek-ai/DeepSeek-V4-Flash-Vision-Exp for image input)
 transport: ib
 head_ip: 192.168.100.1
 worker_ip: 192.168.100.2
 container: vllm
-rdma_hca: mlx4_0:1     # NCCL_IB_HCA pin: the ConnectX-3, port 1 (the cabled port)
-api_port: 1236
-disk_kv: false
+control_iface_head: thunderbolt0    # NCCL/GLOO bootstrap-socket interface per box
+control_iface_worker: thunderbolt0
+rdma_hca: mlx4_0:1     # NCCL_IB_HCA pin: HCA and port the cable is on (rdma link shows ACTIVE)
+api_port: 1234
+disk_kv: true
 disk_kv_gib: 30
 max_ctx: 524288
 kv_pin_gib: 6
 gpu_mem_util: 0.83
 warmup_ctx: 2048
-spec_tokens: 5       # MTP-5, same as production

--- a/host/ds4-vllm-manual-serve.sh
+++ b/host/ds4-vllm-manual-serve.sh
@@ -145,8 +145,36 @@ if (( ${DS4_SPEC_TOKENS:-5} > 0 )); then
     SPEC_ARGS=(--speculative-config "{\"method\":\"deepseek_mtp\",\"num_speculative_tokens\":${DS4_SPEC_TOKENS:-5},\"disable_padded_drafter_batch\":true,\"enforce_eager\":true}")
   fi
 fi
-exec vllm serve "${DS4_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}" \
+# Vision checkpoint detection. DeepSeek-V4-Flash-Vision-Exp's config.json
+# still declares the text architecture, so vLLM would load it text-only; the
+# marker that distinguishes it is vision_n_layers (the same key the patched
+# engine gates its vision paths on). When the checkpoint pointed at by model:
+# declares it, select the multimodal wrapper with --hf-overrides. The same
+# override declares num_nextn_predict_layers=1: Vision-Exp declares its
+# three-stage DSpark drafter as 3 where the text checkpoint declares 1, the
+# drafter is one predictor either way (the stages are internal to it), and 1
+# keeps vLLM's num_speculative_tokens check on the MTP-5 shape.
+# config.json is read from the local dir or the HF cache (a cached repo
+# resolves offline); if it cannot be read, serve as text and say so.
+MODEL=${DS4_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
+VISION_LAYERS=$(/opt/venv/bin/python3 - "$MODEL" <<'PYEOF'
+import json, os, sys
+model = sys.argv[1]
+path = os.path.join(model, "config.json")
+if not os.path.isfile(path):
+    from huggingface_hub import hf_hub_download
+    path = hf_hub_download(model, "config.json")
+print(int(json.load(open(path)).get("vision_n_layers") or 0))
+PYEOF
+) || { echo "[manual-serve] WARNING: could not read $MODEL/config.json -- serving as a text checkpoint"; VISION_LAYERS=0; }
+HF_OVERRIDE_ARGS=()
+if [ "${VISION_LAYERS:-0}" -gt 0 ]; then
+  echo "[manual-serve] vision checkpoint (vision_n_layers=$VISION_LAYERS): serving the multimodal wrapper"
+  HF_OVERRIDE_ARGS=(--hf-overrides '{"architectures":["DeepseekV4VForConditionalGeneration"],"num_nextn_predict_layers":1}')
+fi
+exec vllm serve "$MODEL" \
   --served-model-name deepseek-v4-flash \
+  "${HF_OVERRIDE_ARGS[@]}" \
   --tensor-parallel-size 2 \
   --distributed-executor-backend ray \
   --kv-cache-dtype fp8 \

--- a/tests/test_deepseek_v4_vision.py
+++ b/tests/test_deepseek_v4_vision.py
@@ -1,0 +1,95 @@
+"""Pure gates for the DeepSeek-V4 vision overlay.
+
+These tests intentionally avoid importing torch/vLLM so they run on the host
+and in CI before the 35 GB serving image is available.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from pathlib import Path
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[1]
+MM_PREPROCESS = (
+    REPO
+    / "container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/mm_preprocess.py"
+)
+VISION_DIR = MM_PREPROCESS.parent
+PATCH = REPO / "container/patches/vllm-upstream.patch"
+
+
+def patch_text() -> str:
+    return PATCH.read_text()
+
+
+def load_pure_preprocess() -> dict[str, object]:
+    tree = ast.parse(MM_PREPROCESS.read_text())
+    wanted = {
+        "grid_tokens",
+        "solve_resize_ratio",
+        "safe_resize",
+        "compress_pad_for_start",
+        "image_token_count_for_size",
+    }
+    body: list[ast.stmt] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if names & {"COMPRESS_PAD_TO"}:
+                body.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in wanted:
+            body.append(node)
+    namespace: dict[str, object] = {"math": math}
+    exec(compile(ast.Module(body=body, type_ignores=[]), str(MM_PREPROCESS), "exec"), namespace)
+    return namespace
+
+
+class TestDeepseekV4VisionPreprocessing(unittest.TestCase):
+    def test_supplied_images_match_reference_token_counts(self) -> None:
+        ns = load_pure_preprocess()
+        count = ns["image_token_count_for_size"]
+        self.assertEqual(count(1024, 701, 0), 313)  # carrots.jpeg
+        # The 450x308 image is first raised to vision_min_pixels.
+        self.assertEqual(count(450, 308, 0), 109)  # corn.jpeg
+
+    def test_c4_leading_padding_depends_on_absolute_prompt_offset(self) -> None:
+        ns = load_pure_preprocess()
+        leading_pad = ns["compress_pad_for_start"]
+        self.assertEqual([leading_pad(i) for i in range(8)], [3, 2, 1, 0, 3, 2, 1, 0])
+        for start in range(16):
+            self.assertEqual((start + leading_pad(start)) % 4, 3)
+
+    def test_vision_tower_and_wrapper_are_packaged(self) -> None:
+        self.assertTrue((VISION_DIR / "vision.py").is_file())
+        self.assertTrue((VISION_DIR / "vision_model.py").is_file())
+        wrapper = (VISION_DIR / "vision_model.py").read_text()
+        self.assertIn("DeepseekV4VForConditionalGeneration", wrapper)
+        self.assertIn("requires_raw_input_tokens = True", wrapper)
+        self.assertIn("DeepseekV4VMultiModalProcessor", wrapper)
+
+    def test_registry_and_input_validation_support_the_override_arch(self) -> None:
+        patch = patch_text()
+        self.assertIn('"DeepseekV4VForConditionalGeneration"', patch)
+        self.assertIn("vision_n_layers", patch)
+        self.assertIn("vocab_size + 4", patch)
+
+    def test_amd_path_masks_sentinels_and_registers_visual_bias(self) -> None:
+        patch = patch_text()
+        self.assertIn("self.gate.bias_vl", patch)
+        self.assertIn("input_ids >= self.vision_vocab_size", patch)
+        self.assertIn("torch.zeros_like(input_ids)", patch)
+        self.assertIn("vision_e_score_correction_bias", patch)
+        self.assertIn('name.endswith(".ffn.gate.e_score_correction_bias")', patch)
+
+    def test_visual_router_uses_dynamic_bias_without_changing_text_bias(self) -> None:
+        patch = patch_text()
+        self.assertIn("image_mask.unsqueeze(-1)", patch)
+        self.assertIn("self.e_score_correction_bias", patch)
+        self.assertIn("_topk_softplus_sqrt_torch", patch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deepseek_v4_vision_span.py
+++ b/tests/test_deepseek_v4_vision_span.py
@@ -1,0 +1,181 @@
+"""Span-bidirectional attention: port math vs the DeepSeek reference.
+
+Validates, without a GPU:
+- compute_image_visibility (AST-extracted from vision_model.py) against the
+  reference ``get_image_visible`` from the Vision-Exp checkpoint repo
+  (embedded below as the oracle), on batched [1, seq] layouts.
+- the SWA range arithmetic of the patched ROCm combine kernel (replicated in
+  python) against the reference ``get_window_topk_idxs_visible`` row sets.
+- exact causal equivalence for text-only batches.
+
+Needs torch; skipped where unavailable (run inside the vllm container).
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+try:
+    import torch
+except ImportError:  # pragma: no cover
+    torch = None
+
+ROOT = Path(__file__).resolve().parents[1]
+VISION_MODEL = (
+    ROOT
+    / "container/rootfs/opt/venv/lib/python3.12/site-packages/vllm/models"
+    / "deepseek_v4/vision_model.py"
+)
+ROCM = ROOT  # kernel arithmetic replicated inline; source checked textually
+
+VOCAB = 129280
+MAX_IMG = 384
+WIN = 128
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+
+
+def load_compute_image_visibility():
+    tree = ast.parse(VISION_MODEL.read_text())
+    body = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "compute_image_visibility"
+    ]
+    ns = {"torch": torch, "IMAGE_START": IMAGE_START, "IMAGE_END": IMAGE_END}
+    exec(compile(ast.Module(body=body, type_ignores=[]), str(VISION_MODEL), "exec"), ns)
+    return ns["compute_image_visibility"]
+
+
+# --- reference oracle (DeepSeek-V4-Flash-Vision-Exp inference/model.py) -----
+
+def ref_get_image_visible(input_ids, vocab_size, max_image_tokens):
+    seqlen = input_ids.size(1)
+    idx = torch.arange(seqlen, dtype=torch.int32).unsqueeze(0)
+    is_start = input_ids == vocab_size + IMAGE_START
+    is_end = input_ids == vocab_size + IMAGE_END
+    valid = (is_start.cumsum(1) > is_end.cumsum(1)) | is_end
+    starts = torch.where(is_start, idx, 0).cummax(1)[0]
+    left = (idx - starts) * valid
+    ends = torch.where(is_end, idx, seqlen).flip(1).cummin(1)[0].flip(1)
+    right = (ends - idx) * valid
+    return left.clamp(max=max_image_tokens - 1), right.clamp(max=max_image_tokens)
+
+
+def ref_get_window_topk_idxs_visible(window_size, seqlen, left, right, max_image_tokens):
+    width = min(seqlen, window_size + max_image_tokens)
+    idx = torch.arange(seqlen).unsqueeze(0)
+    left_add = (left - (window_size - 1)).clamp(min=0)
+    starts = (idx - (window_size - 1) - left_add).clamp(min=0)
+    matrix = starts.unsqueeze(-1) + torch.arange(width)
+    matrix = torch.where(matrix > (idx + right).unsqueeze(-1), -1, matrix)
+    return matrix.int().contiguous()
+
+
+# --- replicated kernel arithmetic (amd/rocm.py combine kernel) --------------
+
+def kernel_swa_range(pos, vleft, vright, win, seq_len, gather_start, swa_width):
+    left_add = max(vleft - (win - 1), 0)
+    swa_start = max(pos - (win - 1) - left_add, 0, gather_start)
+    swa_end = min(pos + vright, seq_len - 1)
+    swa_len = min(swa_end - swa_start + 1, swa_width)
+    return swa_start, swa_len
+
+
+def kernel_swa_range_causal(pos, win):
+    swa_len = min(pos + 1, win)
+    return pos - swa_len + 1, swa_len
+
+
+def make_span(n_img, n_newlines=2, n_pads=2):
+    return (
+        [VOCAB + IMAGE_START]
+        + [VOCAB + IMAGE_PAD] * n_pads
+        + [VOCAB + IMAGE] * n_img
+        + [VOCAB + IMAGE_NEW_LINE] * n_newlines
+        + [VOCAB + IMAGE_END]
+    )
+
+
+@unittest.skipUnless(torch is not None, "torch required")
+class SpanVisibilityTests(unittest.TestCase):
+    def setUp(self):
+        self.compute = load_compute_image_visibility()
+
+    def _ids(self, layout):
+        return torch.tensor(layout, dtype=torch.int64)
+
+    def test_matches_reference_on_intact_spans(self):
+        g = torch.Generator().manual_seed(7)
+        for _ in range(25):
+            seq = []
+            for _ in range(int(torch.randint(1, 4, (1,), generator=g))):
+                seq += torch.randint(0, VOCAB, (int(torch.randint(1, 60, (1,), generator=g)),), generator=g).tolist()
+                seq += make_span(int(torch.randint(1, MAX_IMG + 1, (1,), generator=g)))
+            seq += torch.randint(0, VOCAB, (30,), generator=g).tolist()
+            ids = self._ids(seq)
+            left, right = self.compute(ids, VOCAB, MAX_IMG)
+            rl, rr = ref_get_image_visible(ids.unsqueeze(0), VOCAB, MAX_IMG)
+            torch.testing.assert_close(left, rl[0].to(torch.int32))
+            torch.testing.assert_close(right, rr[0].to(torch.int32))
+
+    def test_text_only_is_all_zero(self):
+        ids = self._ids(list(range(500)))
+        left, right = self.compute(ids, VOCAB, MAX_IMG)
+        self.assertEqual(int(left.abs().sum()), 0)
+        self.assertEqual(int(right.abs().sum()), 0)
+
+    def test_truncated_fragments_are_causal(self):
+        span = make_span(16)
+        # END lost to the next chunk
+        headless = self._ids([1, 2] + span[:-3])
+        left, right = self.compute(headless, VOCAB, MAX_IMG)
+        self.assertEqual(int(left.abs().sum()), 0)
+        self.assertEqual(int(right.abs().sum()), 0)
+        # START lost to the previous chunk
+        tailless = self._ids(span[3:] + [1, 2])
+        left, right = self.compute(tailless, VOCAB, MAX_IMG)
+        self.assertEqual(int(left.abs().sum()), 0)
+        self.assertEqual(int(right.abs().sum()), 0)
+
+    def test_kernel_ranges_match_reference_rows(self):
+        seq = (
+            list(range(50))
+            + make_span(40)
+            + list(range(60))
+            + make_span(200)
+            + list(range(40))
+        )
+        ids = self._ids(seq)
+        n = len(seq)
+        left, right = self.compute(ids, VOCAB, MAX_IMG)
+        ref = ref_get_window_topk_idxs_visible(
+            WIN, n, left.unsqueeze(0).to(torch.int64),
+            right.unsqueeze(0).to(torch.int64), MAX_IMG,
+        )[0]
+        for pos in range(n):
+            expected = set(ref[pos][ref[pos] >= 0].tolist())
+            start, ln = kernel_swa_range(
+                pos, int(left[pos]), int(right[pos]),
+                WIN, seq_len=n, gather_start=0, swa_width=WIN + MAX_IMG,
+            )
+            self.assertEqual(set(range(start, start + ln)), expected, f"pos={pos}")
+
+    def test_kernel_causal_path_unchanged_for_text(self):
+        for pos in range(300):
+            vis = kernel_swa_range(pos, 0, 0, WIN, 10_000, 0, WIN + MAX_IMG)
+            causal = kernel_swa_range_causal(pos, WIN)
+            self.assertEqual(vis, causal)
+
+    def test_kernel_range_never_exceeds_buffer(self):
+        # width bound: swa_len <= WIN + MAX_IMG for any clamped (left, right)
+        for vleft in (0, WIN - 1, MAX_IMG - 1):
+            for vright in (0, 1, MAX_IMG):
+                _, ln = kernel_swa_range(
+                    5_000, vleft, vright, WIN, 1_000_000, 0, WIN + MAX_IMG
+                )
+                self.assertLessEqual(ln, WIN + MAX_IMG)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Port of the Vision-Exp support: point model: in ds4-config.yaml at the deepseek-ai/DeepSeek-V4-Flash-Vision-Exp checkpoint and the stack serves it with image input through the OpenAI chat image_url parts. No config flag: the launcher reads the checkpoint's config.json and, when it declares a vision tower (vision_n_layers, absent from the text checkpoint), passes --hf-overrides selecting the multimodal wrapper and declaring the drafter as one predictor layer -- the checkpoint's own config still names the text architecture and declares its three-stage DSpark drafter as 3 layers.

Engine (patch + overlay, applies cleanly to the pinned base; 41 patched / 21 new files):
- new: mm_preprocess.py (reference resize/grid/C4 token layout and the multimodal processor), vision.py (BF16 ViT + aligner), vision_model.py (DeepseekV4VForConditionalGeneration wrapper: weight mapping, sentinel block embedding merge, per-token image-span visibility, DSpark stash delegation and image_token_index for the MTP proposer)
- registry: register the override architecture; input_processor: admit the five out-of-vocabulary image sentinel ids when a vision tower is configured
- fused_topk_bias_router + amd/model.py: per-token visual expert selection bias (image positions) with the text bias and fused selector untouched for text; sentinel ids substituted before hash-table routing; hash layers skip the serialized gate bias on load
- amd/rocm.py: the sparse-SWA prefill combine kernel takes per-token span visibility so attention is bidirectional inside [IMAGE_START..IMAGE_END] as in the reference; text tokens keep the exact causal window. DS4_VISION_SPAN_ATTN=0 keeps image spans causal
- config/speculative.py: n_predict=1 for every deepseek_v4 draft config (the fresh-loaded draft config cannot see a target --hf-overrides)
- dspark_mtp.py: always build exactly one predictor layer; the checkpoint's mtp.{0,1,2} stages are internal to it

Host: the launcher's checkpoint detection; the process reaps no longer assume the model id starts with "deepseek" (a local weights path does not).

Tests: preprocessing token-count/padding gates and the span-visibility port vs the reference formulas (torch; skips on a bare host).